### PR TITLE
replace sqlite importer and query

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@ Checks: >
   -modernize-use-trailing-return-type,
   -readability-identifier-length,
   -readability-magic-numbers,
+  -readability-function-cognitive-complexity,
   -bugprone-easily-swappable-parameters
 
 CheckOptions:

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "external/glaze"]
 	path = external/glaze
 	url = https://github.com/stephenberry/glaze
+[submodule "external/pthash"]
+	path = external/pthash
+	url = https://github.com/jermp/pthash.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,15 +6,16 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-find_package(SQLite3 REQUIRED)
 find_package(zstd REQUIRED)
 
 add_subdirectory(external/zip)
 add_subdirectory(external/glaze)
+add_subdirectory(external/pthash)
 
 target_compile_definitions(zip PRIVATE MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS)
 
 add_library(yomitandicts
+    src/hash/hash.cpp
     src/importer.cpp
     src/json/yomitan_parser.cpp
     src/text_processor/text_processor.cpp
@@ -29,9 +30,9 @@ target_include_directories(yomitandicts PUBLIC
 )
 
 target_link_libraries(yomitandicts PRIVATE
+    PTHASH
     zip
     glaze::glaze
-    SQLite::SQLite3
     zstd::libzstd_static
 )
 
@@ -40,12 +41,13 @@ add_executable(yomitandicts-cpp
 )
 
 target_link_libraries(yomitandicts-cpp PRIVATE
+    PTHASH
     glaze::glaze
     yomitandicts
 )
 
 add_executable(benchmark-import
-    tests/import.cpp
+    benchmark/import.cpp
 )
 
 target_link_libraries(benchmark-import PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,3 +53,11 @@ add_executable(benchmark-import
 target_link_libraries(benchmark-import PRIVATE
     yomitandicts
 )
+
+add_executable(benchmark-lookup
+    benchmark/lookup.cpp
+)
+
+target_link_libraries(benchmark-lookup PRIVATE
+    yomitandicts
+)

--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,11 @@ let package = Package(
                 .headerSearchPath("external/zip/src"),
                 .headerSearchPath("external/utfcpp/source"),
                 .headerSearchPath("external/glaze/include"),
+                .headerSearchPath("external/pthash/include"),
+                .headerSearchPath("external/pthash/external/bits/include"),
+                .headerSearchPath("external/pthash/external/bits/external/essentials/include"),
+                .headerSearchPath("external/pthash/external/mm_file/include"),
+                .headerSearchPath("external/pthash/external/xxHash"),
                 .unsafeFlags(["-Wno-missing-braces"]),
             ],
             swiftSettings: [

--- a/Package.swift
+++ b/Package.swift
@@ -41,9 +41,6 @@ let package = Package(
             ],
             swiftSettings: [
                 .interoperabilityMode(.Cxx)
-            ],
-            linkerSettings: [
-                .linkedLibrary("sqlite3")
             ]
         ),
     ],

--- a/benchmark/import.cpp
+++ b/benchmark/import.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv) {
       }
       const std::chrono::duration<double, std::milli> elapsed = end - start;
       durations.push_back(elapsed.count());
-      std::filesystem::remove(result.title + ".db");
+      std::filesystem::remove_all(result.title);
     }
   }
 

--- a/benchmark/lookup.cpp
+++ b/benchmark/lookup.cpp
@@ -1,0 +1,51 @@
+#include <algorithm>
+#include <chrono>
+#include <numeric>
+#include <print>
+#include <vector>
+
+#include "yomitandicts/deinflector.hpp"
+#include "yomitandicts/lookup.hpp"
+#include "yomitandicts/query.hpp"
+
+int main(int argc, char** argv) {
+  if (argc < 4) {
+    std::println(stderr, "{} <dict_path> <word> <iterations>", argv[0]);
+    return 1;
+  }
+
+  const std::string dict_path = argv[1];
+  const std::string word = argv[2];
+  const int iterations = std::stoi(argv[3]);
+
+  DictionaryQuery query;
+  query.add_term_dict(dict_path);
+  Deinflector deinflector;
+  Lookup lookup(query, deinflector);
+
+  std::vector<double> durations;
+  for (int i = 0; i < iterations; ++i) {
+    const auto start = std::chrono::high_resolution_clock::now();
+    const auto results = lookup.lookup(word);
+    const auto end = std::chrono::high_resolution_clock::now();
+
+    const std::chrono::duration<double, std::milli> elapsed = end - start;
+    durations.push_back(elapsed.count());
+  }
+
+  if (durations.empty()) {
+    return 1;
+  }
+
+  const auto [min, max] = std::ranges::minmax_element(durations);
+  const double total = std::accumulate(durations.begin(), durations.end(), 0.0);
+  const double average = total / durations.size();
+
+  std::println("word: {} iterations: {}", word, iterations);
+  std::println("total: {:.2f}ms", total);
+  std::println("avg: {:.2f}ms", average);
+  std::println("min: {:.2f}ms", *min);
+  std::println("max: {:.2f}ms", *max);
+
+  return 0;
+}

--- a/include/yomitandicts/lookup.hpp
+++ b/include/yomitandicts/lookup.hpp
@@ -21,7 +21,7 @@ class Lookup {
                                    size_t scan_length = 16) const;
 
  private:
-  static std::vector<TermResult> filter_by_pos(const std::vector<TermResult>& terms, const DeinflectionResult& d);
+  static void filter_by_pos(std::vector<TermResult>& terms, const DeinflectionResult& d);
 
   DictionaryQuery& query_;
   Deinflector& deinflector_;

--- a/include/yomitandicts/query.hpp
+++ b/include/yomitandicts/query.hpp
@@ -48,8 +48,8 @@ class DictionaryQuery {
   DictionaryQuery(const DictionaryQuery&) = delete;
   DictionaryQuery& operator=(const DictionaryQuery&) = delete;
 
-  DictionaryQuery(DictionaryQuery&&) = default;
-  DictionaryQuery& operator=(DictionaryQuery&&) = default;
+  DictionaryQuery(DictionaryQuery&&) noexcept;
+  DictionaryQuery& operator=(DictionaryQuery&&) noexcept;
 
   void add_term_dict(const std::string& path);
   void add_freq_dict(const std::string& path);

--- a/src/hash/hash.cpp
+++ b/src/hash/hash.cpp
@@ -1,0 +1,30 @@
+#include "hash.hpp"
+
+#include <pthash.hpp>
+
+namespace hash {
+struct xxhash64_sv {
+  using hash_type = pthash::hash64;
+  static pthash::hash64 hash(std::string_view s, uint64_t seed) {
+    return pthash::hash64{XXH64(s.data(), s.size(), seed)};
+  }
+};
+struct mphf::phf {
+  pthash::single_phf<xxhash64_sv, pthash::skew_bucketer, pthash::compact, true> phf;
+};
+
+mphf::mphf() : ptr_(std::make_unique<phf>()) {};
+mphf::~mphf() = default;
+uint64_t mphf::operator()(std::string_view key) const { return ptr_->phf(key); }
+
+void mphf::build(const std::vector<std::string_view>& keys) {
+  pthash::build_configuration config;
+  config.verbose = false;
+  config.num_threads = std::max<size_t>(1, std::thread::hardware_concurrency());
+  ptr_->phf.build_in_internal_memory(keys.begin(), keys.size(), config);
+}
+
+void mphf::save(const std::string& path) { essentials::save(ptr_->phf, path.c_str()); }
+
+void mphf::load(const std::string& path) { essentials::load(ptr_->phf, path.c_str()); }
+}

--- a/src/hash/hash.hpp
+++ b/src/hash/hash.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace hash {
+class mphf {
+ public:
+  mphf();
+  ~mphf();
+  uint64_t operator()(std::string_view key) const;
+
+  void build(const std::vector<std::string_view>& keys);
+  void save(const std::string& path);
+  void load(const std::string& path);
+
+ private:
+  struct phf;
+  std::unique_ptr<phf> ptr_;
+};
+}

--- a/src/importer.cpp
+++ b/src/importer.cpp
@@ -1,30 +1,46 @@
 #include "yomitandicts/importer.hpp"
 
-#include <sqlite3.h>
 #include <zip.h>
 #include <zstd.h>
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <deque>
 #include <filesystem>
+#include <fstream>
 #include <future>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
+#include "hash/hash.hpp"
 #include "json/yomitan_parser.hpp"
 
 namespace {
-struct MediaFile {
-  std::string path;
-  std::vector<uint8_t> blob;
-};
-
-struct ImportFiles {
+struct Files {
   std::vector<int> term_banks;
   std::vector<int> meta_banks;
   std::vector<int> tag_banks;
   std::vector<int> media_files;
 };
+
+struct ProcessedFile {
+  std::vector<char> data;
+  std::unordered_map<std::string, std::vector<uint64_t>> offsets;
+  size_t count = 0;
+};
+
+struct MediaFile {
+  std::string path;
+  std::vector<char> blob;
+};
+
+void setup_stream_exceptions(std::ofstream& stream) { stream.exceptions(std::ios::failbit | std::ios::badbit); }
 
 std::string read_file_by_index(zip_t* archive, int index) {
   if (zip_entry_openbyindex(archive, index) != 0) {
@@ -93,8 +109,8 @@ std::optional<MediaFile> read_media_by_index(zip_t* archive, int index) {
   return out;
 }
 
-ImportFiles get_files(zip_t* archive) {
-  ImportFiles files;
+Files get_files(zip_t* archive) {
+  Files files;
   const ssize_t num_entries = zip_entries_total(archive);
   if (num_entries < 0) {
     return files;
@@ -129,216 +145,272 @@ ImportFiles get_files(zip_t* archive) {
   return files;
 }
 
-void compress_glossary(const char* src, size_t size, std::vector<char>& compressed, ZSTD_CCtx* cctx) {
+void write_u8(std::vector<char>& out, uint8_t value) { out.push_back(static_cast<char>(value)); }
+
+void write_u16(std::vector<char>& out, uint16_t value) {
+  const size_t old_size = out.size();
+  out.resize(old_size + sizeof(uint16_t));
+  std::memcpy(out.data() + old_size, &value, sizeof(uint16_t));
+}
+
+void write_u32(std::vector<char>& out, uint32_t value) {
+  const size_t old_size = out.size();
+  out.resize(old_size + sizeof(uint32_t));
+  std::memcpy(out.data() + old_size, &value, sizeof(uint32_t));
+}
+
+void write_u64(std::vector<char>& out, uint64_t value) {
+  const size_t old_size = out.size();
+  out.resize(old_size + sizeof(uint64_t));
+  std::memcpy(out.data() + old_size, &value, sizeof(uint64_t));
+}
+
+void write_str(std::vector<char>& out, std::string_view value) {
+  if (value.empty()) {
+    return;
+  }
+  const size_t old_size = out.size();
+  out.resize(old_size + value.size());
+  std::memcpy(out.data() + old_size, value.data(), value.size());
+}
+
+void write_bytes(std::vector<char>& out, const void* data, size_t n) {
+  const size_t old_size = out.size();
+  out.resize(old_size + n);
+  std::memcpy(out.data() + old_size, data, n);
+}
+
+void merge_offsets(std::unordered_map<std::string, std::vector<uint64_t>>& a,
+                   std::unordered_map<std::string, std::vector<uint64_t>>& b, uint64_t write_offset) {
+  for (auto& [key, b_offsets] : b) {
+    for (auto& offset : b_offsets) {
+      offset += write_offset;
+    }
+
+    auto it = a.find(key);
+    if (it == a.end()) {
+      a.emplace(key, std::move(b_offsets));
+    } else {
+      auto& values = it->second;
+      values.insert(values.end(), b_offsets.begin(), b_offsets.end());
+    }
+  }
+}
+
+ProcessedFile process_term_bank(const std::string& content) {
+  ProcessedFile processed;
+  if (content.empty()) {
+    return processed;
+  }
+
+  std::vector<Term> out;
+  if (!yomitan_parser::parse_term_bank(content, out)) {
+    return processed;
+  }
+
+  std::vector<char> compressed;
+  ZSTD_CCtx* cctx = ZSTD_createCCtx();
   if (!cctx) {
-    return;
+    return processed;
   }
 
-  size_t bound = ZSTD_compressBound(size);
-  compressed.resize(bound);
-  size_t compressed_size = ZSTD_compressCCtx(cctx, compressed.data(), bound, src, size, 1);
-  if (ZSTD_isError(compressed_size)) {
-    return;
+  for (auto& term : out) {
+    const std::string_view glossary = term.glossary.str;
+    const size_t bound = ZSTD_compressBound(glossary.size());
+    compressed.resize(bound);
+    const size_t compressed_size =
+        ZSTD_compressCCtx(cctx, compressed.data(), bound, glossary.data(), glossary.size(), 0);
+    if (ZSTD_isError(compressed_size)) {
+      ZSTD_freeCCtx(cctx);
+      throw std::runtime_error("failed to compress glossary");
+    }
+
+    uint64_t offset = processed.data.size();
+    std::string_view expr = term.expression;
+    std::string_view reading = term.reading.empty() ? expr : term.reading;
+    std::string_view blob{compressed.data(), compressed_size};
+
+    write_u8(processed.data, 0);
+    write_u16(processed.data, expr.size());
+    write_str(processed.data, expr);
+    write_u16(processed.data, reading.size());
+    write_str(processed.data, reading);
+    write_u32(processed.data, blob.size());
+    write_str(processed.data, blob);
+    write_u8(processed.data, term.definition_tags.size());
+    write_str(processed.data, term.definition_tags);
+    write_u8(processed.data, term.rules.size());
+    write_str(processed.data, term.rules);
+    write_u8(processed.data, term.term_tags.size());
+    write_str(processed.data, term.term_tags);
+
+    processed.offsets[std::string(expr)].push_back(offset);
+    if (reading != expr) {
+      processed.offsets[std::string(reading)].push_back(offset);
+    }
+    processed.count++;
   }
-  compressed.resize(compressed_size);
+  ZSTD_freeCCtx(cctx);
+
+  return processed;
 }
 
-void init_db(sqlite3* db) {
-  sqlite3_exec(db,
-               "PRAGMA journal_mode=OFF;"
-               "PRAGMA synchronous=OFF;"
-               "PRAGMA temp_store=MEMORY;"
-               "PRAGMA cache_size=-100000;"
-               "PRAGMA page_size=32768;",
-               nullptr, nullptr, nullptr);
-
-  sqlite3_exec(db, R"(
-            CREATE TABLE info (title TEXT, revision TEXT, format INTEGER, styles TEXT);
-            CREATE TABLE terms (expression TEXT, reading TEXT, definition_tags TEXT, rules TEXT, score INTEGER, glossary BLOB, sequence INTEGER, term_tags TEXT);
-            CREATE TABLE term_meta (expression TEXT, mode TEXT, data TEXT);
-            CREATE TABLE tags (name TEXT, category TEXT, sort_order INTEGER, notes TEXT, score INTEGER);
-            CREATE TABLE media (path TEXT PRIMARY KEY, data BLOB);
-        )",
-               nullptr, nullptr, nullptr);
-}
-
-void store_index(sqlite3* db, const Index& index, const std::string& styles) {
-  sqlite3_stmt* stmt;
-  sqlite3_prepare_v2(db, "INSERT INTO info VALUES (?, ?, ?, ?)", -1, &stmt, nullptr);
-  sqlite3_bind_text(stmt, 1, index.title.data(), static_cast<int>(index.title.size()), SQLITE_STATIC);
-  sqlite3_bind_text(stmt, 2, index.revision.data(), static_cast<int>(index.revision.size()), SQLITE_STATIC);
-  sqlite3_bind_int(stmt, 3, index.format);
-  if (!styles.empty()) {
-    sqlite3_bind_text(stmt, 4, styles.c_str(), -1, SQLITE_STATIC);
-  } else {
-    sqlite3_bind_null(stmt, 4);
+ProcessedFile process_meta_bank(const std::string& content) {
+  ProcessedFile processed;
+  if (content.empty()) {
+    return processed;
   }
-  sqlite3_step(stmt);
-  sqlite3_finalize(stmt);
+
+  std::vector<Meta> out;
+  if (!yomitan_parser::parse_meta_bank(content, out)) {
+    return processed;
+  }
+
+  for (auto& meta : out) {
+    uint64_t offset = processed.data.size();
+    std::string_view expr = meta.expression;
+    std::string_view mode = meta.mode;
+    std::string_view data = meta.data.str;
+
+    write_u8(processed.data, 1);
+    write_u16(processed.data, expr.size());
+    write_str(processed.data, expr);
+    write_u8(processed.data, mode.size());
+    write_str(processed.data, mode);
+    write_u32(processed.data, data.size());
+    write_str(processed.data, data);
+
+    processed.offsets[std::string(expr)].push_back(offset);
+    processed.count++;
+  }
+
+  return processed;
 }
 
-void store_terms(sqlite3* db, zip_t* archive, const std::vector<int>& files, ImportResult& result) {
+void write_terms(std::ofstream& file, std::unordered_map<std::string, std::vector<uint64_t>>& offsets, zip_t* archive,
+                 const std::vector<int>& files, uint64_t& write_offset, ImportResult& result) {
   if (files.empty()) {
     return;
   }
 
-  sqlite3_stmt* stmt;
-  sqlite3_prepare_v2(db, "INSERT INTO terms VALUES (?, ?, ?, ?, ?, ?, ?, ?)", -1, &stmt, nullptr);
-
-  const size_t num_threads = std::max(1U, std::thread::hardware_concurrency() - 1);
-  for (int index : files) {
-    std::string content = read_file_by_index(archive, index);
-    if (content.empty()) {
-      continue;
+  size_t max_threads = std::max<size_t>(2, static_cast<const unsigned long>(std::thread::hardware_concurrency() * 2));
+  std::deque<std::future<ProcessedFile>> threads;
+  auto write_processed = [&](ProcessedFile&& processed) {
+    if (processed.data.empty()) {
+      return;
     }
+    file.write(processed.data.data(), static_cast<std::streamsize>(processed.data.size()));
+    merge_offsets(offsets, processed.offsets, write_offset);
+    write_offset += processed.data.size();
+    result.term_count += processed.count;
+  };
 
-    std::vector<Term> out;
-    if (!yomitan_parser::parse_term_bank(content, out)) {
-      continue;
-    }
+  for (int file_index : files) {
+    std::string content = read_file_by_index(archive, file_index);
+    threads.push_back(
+        std::async(std::launch::async, [content = std::move(content)]() { return process_term_bank(content); }));
 
-    std::vector<std::vector<char>> glossaries(out.size());
-    std::vector<std::future<void>> futures;
-    size_t chunk_size = std::max<size_t>(1, out.size() / num_threads);
-    for (size_t i = 0; i < num_threads; i++) {
-      size_t start = i * chunk_size;
-      size_t end = (i == num_threads - 1) ? out.size() : std::min(out.size(), start + chunk_size);
-      if (start >= out.size()) {
-        break;
-      }
-      futures.push_back(std::async(std::launch::async, [&glossaries, &out, start, end] {
-        ZSTD_CCtx* cctx = ZSTD_createCCtx();
-        for (size_t t = start; t < end; t++) {
-          compress_glossary(out[t].glossary.str.data(), out[t].glossary.str.size(), glossaries[t], cctx);
-        }
-        ZSTD_freeCCtx(cctx);
-      }));
-    }
-    for (const auto& f : futures) {
-      f.wait();
-    }
-
-    for (size_t i = 0; i < out.size(); ++i) {
-      const auto& term = out[i];
-      sqlite3_bind_text(stmt, 1, term.expression.data(), static_cast<int>(term.expression.size()), SQLITE_STATIC);
-      if (term.reading.empty()) {
-        sqlite3_bind_text(stmt, 2, term.expression.data(), static_cast<int>(term.expression.size()), SQLITE_STATIC);
-      } else {
-        sqlite3_bind_text(stmt, 2, term.reading.data(), static_cast<int>(term.reading.size()), SQLITE_STATIC);
-      }
-      sqlite3_bind_text(stmt, 3, term.definition_tags.data(), static_cast<int>(term.definition_tags.size()),
-                        SQLITE_STATIC);
-      sqlite3_bind_text(stmt, 4, term.rules.data(), static_cast<int>(term.rules.size()), SQLITE_STATIC);
-      sqlite3_bind_int(stmt, 5, term.score);
-
-      sqlite3_bind_blob(stmt, 6, glossaries[i].data(), static_cast<int>(glossaries[i].size()), SQLITE_STATIC);
-
-      sqlite3_bind_int(stmt, 7, term.sequence);
-      sqlite3_bind_text(stmt, 8, term.term_tags.data(), static_cast<int>(term.term_tags.size()), SQLITE_STATIC);
-
-      sqlite3_step(stmt);
-      sqlite3_reset(stmt);
-      result.term_count++;
+    if (threads.size() == max_threads) {
+      write_processed(threads.front().get());
+      threads.pop_front();
     }
   }
-  sqlite3_finalize(stmt);
+
+  while (!threads.empty()) {
+    write_processed(threads.front().get());
+    threads.pop_front();
+  }
 }
 
-void store_meta(sqlite3* db, zip_t* archive, const std::vector<int>& files, ImportResult& result) {
+void write_meta(std::ofstream& file, std::unordered_map<std::string, std::vector<uint64_t>>& offsets, zip_t* archive,
+                const std::vector<int>& files, uint64_t& write_offset, ImportResult& result) {
   if (files.empty()) {
     return;
   }
 
-  sqlite3_stmt* stmt;
-  sqlite3_prepare_v2(db, "INSERT INTO term_meta VALUES (?, ?, ?)", -1, &stmt, nullptr);
-
-  for (int index : files) {
-    std::string content = read_file_by_index(archive, index);
-    if (content.empty()) {
-      continue;
+  size_t max_threads = std::max<size_t>(2, static_cast<const unsigned long>(std::thread::hardware_concurrency() * 2));
+  std::deque<std::future<ProcessedFile>> threads;
+  auto write_processed = [&](ProcessedFile&& processed) {
+    if (processed.data.empty()) {
+      return;
     }
+    file.write(processed.data.data(), static_cast<std::streamsize>(processed.data.size()));
+    merge_offsets(offsets, processed.offsets, write_offset);
+    write_offset += processed.data.size();
+    result.meta_count += processed.count;
+  };
 
-    std::vector<Meta> out;
-    if (!yomitan_parser::parse_meta_bank(content, out)) {
-      continue;
-    }
+  for (int file_index : files) {
+    std::string content = read_file_by_index(archive, file_index);
+    threads.push_back(
+        std::async(std::launch::async, [content = std::move(content)]() { return process_meta_bank(content); }));
 
-    for (const auto& meta : out) {
-      sqlite3_bind_text(stmt, 1, meta.expression.data(), static_cast<int>(meta.expression.size()), SQLITE_STATIC);
-      sqlite3_bind_text(stmt, 2, meta.mode.data(), static_cast<int>(meta.mode.size()), SQLITE_STATIC);
-      sqlite3_bind_text(stmt, 3, meta.data.str.data(), static_cast<int>(meta.data.str.size()), SQLITE_STATIC);
-
-      sqlite3_step(stmt);
-      sqlite3_reset(stmt);
-      result.meta_count++;
+    if (threads.size() == max_threads) {
+      write_processed(threads.front().get());
+      threads.pop_front();
     }
   }
-  sqlite3_finalize(stmt);
+
+  while (!threads.empty()) {
+    write_processed(threads.front().get());
+    threads.pop_front();
+  }
 }
 
-void store_tags(sqlite3* db, zip_t* archive, const std::vector<int>& files, ImportResult& result) {
+void write_offset_index(std::ostream& file, std::unordered_map<std::string, std::vector<uint64_t>>& offsets,
+                        uint64_t& write_offset, std::vector<std::string_view>& keys,
+                        std::vector<uint64_t>& key_offsets) {
+  std::vector<char> offset_buf;
+  for (auto& [key, offs] : offsets) {
+    keys.push_back(key);
+    key_offsets.push_back(write_offset);
+
+    write_u32(offset_buf, offs.size());
+    write_bytes(offset_buf, offs.data(), offs.size() * sizeof(uint64_t));
+
+    write_offset += sizeof(uint32_t) + offs.size() * sizeof(uint64_t);
+  }
+  file.write(offset_buf.data(), static_cast<std::streamsize>(offset_buf.size()));
+}
+
+void write_media(const std::string& path, zip_t* archive, const std::vector<int>& files, ImportResult& result) {
   if (files.empty()) {
     return;
   }
 
-  sqlite3_stmt* stmt;
-  sqlite3_prepare_v2(db, "INSERT INTO tags VALUES (?, ?, ?, ?, ?)", -1, &stmt, nullptr);
+  std::ofstream blobs(path + "/media.bin", std::ios::binary);
+  std::ofstream index(path + "/media_index.bin", std::ios::binary);
+  setup_stream_exceptions(blobs);
+  setup_stream_exceptions(index);
 
-  for (int index : files) {
-    std::string content = read_file_by_index(archive, index);
-    if (content.empty()) {
-      continue;
-    }
-
-    std::vector<Tag> out;
-    if (!yomitan_parser::parse_tag_bank(content, out)) {
-      continue;
-    }
-
-    for (const auto& tag : out) {
-      sqlite3_bind_text(stmt, 1, tag.name.data(), static_cast<int>(tag.name.size()), SQLITE_STATIC);
-      sqlite3_bind_text(stmt, 2, tag.category.data(), static_cast<int>(tag.category.size()), SQLITE_STATIC);
-      sqlite3_bind_int(stmt, 3, tag.order);
-      sqlite3_bind_text(stmt, 4, tag.notes.data(), static_cast<int>(tag.notes.size()), SQLITE_STATIC);
-      sqlite3_bind_int(stmt, 5, tag.score);
-
-      sqlite3_step(stmt);
-      sqlite3_reset(stmt);
-      result.tag_count++;
-    }
-  }
-  sqlite3_finalize(stmt);
-}
-
-void store_media(sqlite3* db, zip_t* archive, const std::vector<int>& files, ImportResult& result) {
-  if (files.empty()) {
-    return;
-  }
-
-  sqlite3_stmt* stmt;
-  sqlite3_prepare_v2(db, "INSERT INTO media VALUES (?, ?)", -1, &stmt, nullptr);
-
-  for (int index : files) {
-    auto media = read_media_by_index(archive, index);
+  uint64_t write_offset = 0;
+  std::vector<char> blobs_buf;
+  std::vector<char> index_buf;
+  for (int file_index : files) {
+    auto media = read_media_by_index(archive, file_index);
     if (!media.has_value()) {
       continue;
     }
 
-    sqlite3_bind_text(stmt, 1, media->path.data(), static_cast<int>(media->path.size()), SQLITE_STATIC);
-    sqlite3_bind_blob(stmt, 2, media->blob.data(), static_cast<int>(media->blob.size()), SQLITE_STATIC);
+    const auto blob_size = media->blob.size();
+    write_bytes(blobs_buf, media->blob.data(), blob_size);
 
-    sqlite3_step(stmt);
-    sqlite3_reset(stmt);
+    write_u16(index_buf, media->path.size());
+    write_str(index_buf, media->path);
+    write_u64(index_buf, write_offset);
+    write_u32(index_buf, blob_size);
+
+    write_offset += blob_size;
     result.media_count++;
   }
-  sqlite3_finalize(stmt);
+  blobs.write(blobs_buf.data(), static_cast<std::streamsize>(blobs_buf.size()));
+  index.write(index_buf.data(), static_cast<std::streamsize>(index_buf.size()));
 }
 }
 
 ImportResult dictionary_importer::import(const std::string& zip_path, const std::string& output_dir) {
   ImportResult result;
   zip_t* archive = nullptr;
-  sqlite3* db = nullptr;
   try {
     archive = zip_open(zip_path.c_str(), 0, 'r');
     if (!archive) {
@@ -357,38 +429,53 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
 
     result.title = index.title;
 
-    std::filesystem::create_directories(output_dir);
-    std::filesystem::path db_path = std::filesystem::path(output_dir) / (result.title + ".db");
-    std::string path = db_path.string();
+    std::filesystem::path dict_path = std::filesystem::path(output_dir) / result.title;
+    std::string path = dict_path.string();
+    std::filesystem::create_directories(dict_path);
 
-    if (std::filesystem::exists(path)) {
-      std::filesystem::remove(path);
+    if (glz::write_file_json(index, path + "/info.json", std::string{})) {
+      throw std::runtime_error("failed to write info.json");
     }
-
-    if (sqlite3_open(path.c_str(), &db) != SQLITE_OK) {
-      throw std::runtime_error("error opening db");
-    }
-
-    init_db(db);
 
     std::string styles = read_file_by_name(archive, "styles.css");
+    if (!styles.empty()) {
+      std::ofstream styles_file(path + "/styles.css", std::ios::binary);
+      setup_stream_exceptions(styles_file);
+      styles_file.write(styles.data(), static_cast<std::streamsize>(styles.size()));
+    }
 
-    store_index(db, index, styles);
+    const Files files = get_files(archive);
+    std::ofstream blobs(path + "/blobs.bin", std::ios::binary);
+    setup_stream_exceptions(blobs);
+    std::unordered_map<std::string, std::vector<uint64_t>> offsets;
+    uint64_t write_offset = 0;
+    write_terms(blobs, offsets, archive, files.term_banks, write_offset, result);
+    write_meta(blobs, offsets, archive, files.meta_banks, write_offset, result);
+    if (offsets.empty()) {
+      throw std::runtime_error("empty dictionary");
+    }
 
-    const ImportFiles files = get_files(archive);
-    sqlite3_exec(db, "BEGIN", nullptr, nullptr, nullptr);
-    store_terms(db, archive, files.term_banks, result);
-    store_meta(db, archive, files.meta_banks, result);
-    store_tags(db, archive, files.tag_banks, result);
-    store_media(db, archive, files.media_files, result);
-    sqlite3_exec(db, "COMMIT", nullptr, nullptr, nullptr);
+    std::vector<std::string_view> keys;
+    std::vector<uint64_t> key_offsets;
+    write_offset_index(blobs, offsets, write_offset, keys, key_offsets);
+
+    hash::mphf phf;
+    phf.build(keys);
+    phf.save(path + "/hash.mph");
+
+    std::vector<uint64_t> offset_hash_table(keys.size());
+    for (size_t i = 0; i < keys.size(); i++) {
+      auto& key = keys[i];
+      offset_hash_table[phf(key)] = key_offsets[i];
+    }
+    std::ofstream offs(path + "/offsets.bin", std::ios::binary);
+    setup_stream_exceptions(offs);
+    offs.write(reinterpret_cast<const char*>(offset_hash_table.data()),
+              static_cast<std::streamsize>(offset_hash_table.size() * sizeof(uint64_t)));
+
+    write_media(path, archive, files.media_files, result);
+
     result.success = true;
-
-    sqlite3_exec(db, "CREATE INDEX IF NOT EXISTS idx_terms_expression ON terms(expression);", nullptr, nullptr,
-                 nullptr);
-    sqlite3_exec(db, "CREATE INDEX IF NOT EXISTS idx_terms_reading ON terms(reading);", nullptr, nullptr, nullptr);
-    sqlite3_exec(db, "CREATE INDEX IF NOT EXISTS idx_meta_expression_mode ON term_meta(expression, mode);", nullptr,
-                 nullptr, nullptr);
   } catch (const std::exception& e) {
     result.success = false;
     result.errors.emplace_back(e.what());
@@ -396,10 +483,6 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
 
   if (archive) {
     zip_close(archive);
-  }
-
-  if (db) {
-    sqlite3_close(db);
   }
 
   return result;

--- a/src/importer.cpp
+++ b/src/importer.cpp
@@ -229,6 +229,7 @@ ProcessedFile process_term_bank(const std::string& content) {
     std::string_view expr = term.expression;
     std::string_view reading = term.reading.empty() ? expr : term.reading;
     std::string_view blob{compressed.data(), compressed_size};
+    std::string_view definition_tags = term.definition_tags.value_or("");
 
     write_u8(processed.data, 0);
     write_u16(processed.data, expr.size());
@@ -237,8 +238,8 @@ ProcessedFile process_term_bank(const std::string& content) {
     write_str(processed.data, reading);
     write_u32(processed.data, blob.size());
     write_str(processed.data, blob);
-    write_u8(processed.data, term.definition_tags.size());
-    write_str(processed.data, term.definition_tags);
+    write_u8(processed.data, definition_tags.size());
+    write_str(processed.data, definition_tags);
     write_u8(processed.data, term.rules.size());
     write_str(processed.data, term.rules);
     write_u8(processed.data, term.term_tags.size());

--- a/src/importer.cpp
+++ b/src/importer.cpp
@@ -471,7 +471,7 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
     std::ofstream offs(path + "/offsets.bin", std::ios::binary);
     setup_stream_exceptions(offs);
     offs.write(reinterpret_cast<const char*>(offset_hash_table.data()),
-              static_cast<std::streamsize>(offset_hash_table.size() * sizeof(uint64_t)));
+               static_cast<std::streamsize>(offset_hash_table.size() * sizeof(uint64_t)));
 
     write_media(path, archive, files.media_files, result);
 
@@ -483,6 +483,10 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
 
   if (archive) {
     zip_close(archive);
+  }
+
+  if (!result.success && !result.title.empty()) {
+    std::filesystem::remove_all(std::filesystem::path(output_dir) / result.title);
   }
 
   return result;

--- a/src/json/yomitan_parser.cpp
+++ b/src/json/yomitan_parser.cpp
@@ -6,9 +6,10 @@
 template <>
 struct glz::meta<Index> {
   using T = Index;
-  static constexpr auto value = object("title", glz::raw_string<&T::title>, "revision", glz::raw_string<&T::revision>,
-                                       "format", &T::format, "isUpdatable", &T::updatable, "indexUrl",
-                                       glz::raw_string<&T::index_url>, "updateUrl", glz::raw_string<&T::download_url>);
+  static constexpr auto value =
+      object("title", glz::raw_string<&T::title>, "revision", glz::raw_string<&T::revision>, "format", &T::format,
+             "isUpdatable", &T::updatable, "indexUrl", glz::raw_string<&T::index_url>, "downloadUrl",
+             glz::raw_string<&T::download_url>);
 };
 
 template <>
@@ -111,7 +112,8 @@ bool yomitan_parser::parse_tag_bank(std::string_view content, std::vector<Tag>& 
 
 bool yomitan_parser::parse_frequency(std::string_view content, ParsedFrequency& out) {
   internal::RawFrequencyFlat parsed_flat;
-  auto error = glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = true}>(parsed_flat, content);
+  auto error =
+      glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = true}>(parsed_flat, content);
   if (!error) {
     out.reading = parsed_flat.reading.value_or("");
     out.value = parsed_flat.value;

--- a/src/json/yomitan_parser.hpp
+++ b/src/json/yomitan_parser.hpp
@@ -15,7 +15,7 @@ struct Index {
 struct Term {
   std::string_view expression;
   std::string_view reading;
-  std::string_view definition_tags;
+  std::optional<std::string_view> definition_tags;
   std::string_view rules;
   int score = 0;
   glz::raw_json_view glossary;

--- a/src/json/yomitan_parser.hpp
+++ b/src/json/yomitan_parser.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <glaze/glaze.hpp>
+#include <cstdint>
 #include <string_view>
 #include <vector>
 
@@ -19,7 +20,7 @@ struct Term {
   std::string_view rules;
   int score = 0;
   glz::raw_json_view glossary;
-  int sequence = 0;
+  int64_t sequence = 0;
   std::string_view term_tags;
 };
 

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -68,6 +68,9 @@ struct DictionaryQuery::DictionaryData {
 DictionaryQuery::DictionaryQuery() = default;
 DictionaryQuery::~DictionaryQuery() = default;
 
+DictionaryQuery::DictionaryQuery(DictionaryQuery&&) noexcept = default;
+DictionaryQuery& DictionaryQuery::operator=(DictionaryQuery&&) noexcept = default;
+
 void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
   Dictionary dict;
   Index info;

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -1,168 +1,202 @@
 #include "yomitandicts/query.hpp"
 
-#include <sqlite3.h>
+#include <sys/fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <zstd.h>
 
-#include <filesystem>
-#include <map>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <memory>
 #include <ranges>
+#include <string_view>
 
+#include "hash/hash.hpp"
 #include "json/yomitan_parser.hpp"
 
-DictionaryQuery::~DictionaryQuery() {
-  for (auto& [name, styles, db, stmt] : dicts_) {
-    sqlite3_finalize(stmt);
-    sqlite3_close(db);
+namespace {
+uint8_t read_u8(const uint8_t*& addr) { return *addr++; }
+
+uint16_t read_u16(const uint8_t*& addr) {
+  uint16_t result;
+  std::memcpy(&result, addr, sizeof(uint16_t));
+  addr += sizeof(uint16_t);
+  return result;
+}
+
+uint32_t read_u32(const uint8_t*& addr) {
+  uint32_t result;
+  std::memcpy(&result, addr, sizeof(uint32_t));
+  addr += sizeof(uint32_t);
+  return result;
+}
+
+uint64_t read_u64(const uint8_t*& addr) {
+  uint64_t result;
+  std::memcpy(&result, addr, sizeof(uint64_t));
+  addr += sizeof(uint64_t);
+  return result;
+}
+
+std::string_view read_str(const uint8_t*& addr, uint32_t len) {
+  std::string_view result(reinterpret_cast<const char*>(addr), len);
+  addr += len;
+  return result;
+}
+}
+
+struct DictionaryQuery::DictionaryData {
+  hash::mphf phf;
+  uint8_t* blobs = nullptr;
+  size_t blobs_size = 0;
+  uint64_t* offsets = nullptr;
+  size_t offsets_size = 0;
+
+  ~DictionaryData() {
+    if (blobs) {
+      munmap(blobs, blobs_size);
+    }
+    if (offsets) {
+      munmap(offsets, offsets_size);
+    }
   }
-  for (auto& [name, styles, db, stmt] : freq_dicts_) {
-    sqlite3_finalize(stmt);
-    sqlite3_close(db);
+};
+
+DictionaryQuery::DictionaryQuery() = default;
+DictionaryQuery::~DictionaryQuery() = default;
+
+void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
+  Dictionary dict;
+  Index info;
+  std::string buf{};
+  if (glz::read_file_json(info, path + "/info.json", buf)) {
+    return;
   }
-  for (auto& [name, styles, db, stmt] : pitch_dicts_) {
-    sqlite3_finalize(stmt);
-    sqlite3_close(db);
+
+  dict.name = info.title.empty() ? std::filesystem::path(path).stem().string() : info.title;
+  if (std::filesystem::exists(path + "/styles.css")) {
+    std::ifstream f(path + "/styles.css");
+    dict.styles = std::string(std::istreambuf_iterator<char>(f), {});
+  }
+
+  dict.data = std::make_unique<DictionaryData>();
+  dict.data->phf.load(path + "/hash.mph");
+
+  struct stat st{};
+  int fd = open((path + "/offsets.bin").c_str(), O_RDONLY);
+  if (fd == -1) {
+    return;
+  }
+
+  if (fstat(fd, &st) != 0) {
+    close(fd);
+    return;
+  }
+
+  dict.data->offsets_size = st.st_size;
+  dict.data->offsets = reinterpret_cast<uint64_t*>(mmap(nullptr, st.st_size, PROT_READ, MAP_SHARED, fd, 0));
+  if (dict.data->offsets == MAP_FAILED) {
+    close(fd);
+    return;
+  }
+  close(fd);
+
+  fd = open((path + "/blobs.bin").c_str(), O_RDONLY);
+  if (fd < 0) {
+    return;
+  }
+
+  if (fstat(fd, &st) != 0) {
+    close(fd);
+    return;
+  }
+
+  dict.data->blobs_size = st.st_size;
+  dict.data->blobs = reinterpret_cast<uint8_t*>(mmap(nullptr, st.st_size, PROT_READ, MAP_SHARED, fd, 0));
+  if (dict.data->blobs == MAP_FAILED) {
+    close(fd);
+    return;
+  }
+  close(fd);
+
+  switch (type) {
+    case TERM:
+      dicts_.push_back(std::move(dict));
+      break;
+    case FREQ:
+      freq_dicts_.push_back(std::move(dict));
+      break;
+    case PITCH:
+      pitch_dicts_.push_back(std::move(dict));
+      break;
   }
 }
 
-void DictionaryQuery::add_dict(const std::string& db_path) {
-  sqlite3* db;
-  if (sqlite3_open_v2(db_path.c_str(), &db, SQLITE_OPEN_READONLY, nullptr) != SQLITE_OK) {
-    return;
-  }
+void DictionaryQuery::add_term_dict(const std::string& path) { add_dict(path, DictionaryQuery::DictionaryType::TERM); }
 
-  std::string name;
-  std::string styles;
-  sqlite3_stmt* info_stmt;
-  if (sqlite3_prepare_v2(db, "SELECT title, styles FROM info LIMIT 1", -1, &info_stmt, nullptr) == SQLITE_OK) {
-    if (sqlite3_step(info_stmt) == SQLITE_ROW) {
-      const char* title_text = reinterpret_cast<const char*>(sqlite3_column_text(info_stmt, 0));
-      const char* style_text = reinterpret_cast<const char*>(sqlite3_column_text(info_stmt, 1));
+void DictionaryQuery::add_freq_dict(const std::string& path) { add_dict(path, DictionaryQuery::DictionaryType::FREQ); }
 
-      if (title_text) {
-        name = title_text;
-      }
-      if (style_text) {
-        styles = style_text;
-      }
-    }
-  }
-  sqlite3_finalize(info_stmt);
-
-  if (name.empty()) {
-    name = std::filesystem::path(db_path).stem().string();
-  }
-
-  sqlite3_stmt* stmt;
-  if (sqlite3_prepare_v2(db,
-                         "SELECT expression, reading, definition_tags, rules, glossary, term_tags "
-                         "FROM terms WHERE expression = ? OR reading = ?",
-                         -1, &stmt, nullptr) != SQLITE_OK) {
-    sqlite3_close(db);
-    return;
-  }
-  dicts_.emplace_back(std::move(name), std::move(styles), db, stmt);
-}
-
-void DictionaryQuery::add_freq_dict(const std::string& db_path) {
-  sqlite3* db;
-  if (sqlite3_open_v2(db_path.c_str(), &db, SQLITE_OPEN_READONLY, nullptr) != SQLITE_OK) {
-    return;
-  }
-
-  std::string name;
-  sqlite3_stmt* info_stmt;
-  if (sqlite3_prepare_v2(db, "SELECT title FROM info LIMIT 1", -1, &info_stmt, nullptr) == SQLITE_OK) {
-    if (sqlite3_step(info_stmt) == SQLITE_ROW) {
-      const char* title_text = reinterpret_cast<const char*>(sqlite3_column_text(info_stmt, 0));
-
-      if (title_text) {
-        name = title_text;
-      }
-    }
-  }
-  sqlite3_finalize(info_stmt);
-
-  if (name.empty()) {
-    name = std::filesystem::path(db_path).stem().string();
-  }
-
-  sqlite3_stmt* stmt;
-  if (sqlite3_prepare_v2(db, "SELECT data FROM term_meta WHERE expression = ? AND mode = 'freq'", -1, &stmt, nullptr) !=
-      SQLITE_OK) {
-    sqlite3_close(db);
-    return;
-  }
-  freq_dicts_.emplace_back(std::move(name), "", db, stmt);
-}
-
-void DictionaryQuery::add_pitch_dict(const std::string& db_path) {
-  sqlite3* db;
-  if (sqlite3_open_v2(db_path.c_str(), &db, SQLITE_OPEN_READONLY, nullptr) != SQLITE_OK) {
-    return;
-  }
-
-  std::string name;
-  sqlite3_stmt* info_stmt;
-  if (sqlite3_prepare_v2(db, "SELECT title FROM info LIMIT 1", -1, &info_stmt, nullptr) == SQLITE_OK) {
-    if (sqlite3_step(info_stmt) == SQLITE_ROW) {
-      const char* title_text = reinterpret_cast<const char*>(sqlite3_column_text(info_stmt, 0));
-
-      if (title_text) {
-        name = title_text;
-      }
-    }
-  }
-  sqlite3_finalize(info_stmt);
-
-  if (name.empty()) {
-    name = std::filesystem::path(db_path).stem().string();
-  }
-
-  sqlite3_stmt* stmt;
-  if (sqlite3_prepare_v2(db, "SELECT data FROM term_meta WHERE expression = ? AND mode = 'pitch'", -1, &stmt,
-                         nullptr) != SQLITE_OK) {
-    sqlite3_close(db);
-    return;
-  }
-  pitch_dicts_.emplace_back(std::move(name), "", db, stmt);
+void DictionaryQuery::add_pitch_dict(const std::string& path) {
+  add_dict(path, DictionaryQuery::DictionaryType::PITCH);
 }
 
 std::vector<TermResult> DictionaryQuery::query(const std::string& expression) const {
-  std::map<std::pair<std::string, std::string>, TermResult> term_map;
-  for (const auto& [name, styles, db, stmt] : dicts_) {
-    sqlite3_bind_text(stmt, 1, expression.c_str(), -1, SQLITE_STATIC);
-    sqlite3_bind_text(stmt, 2, expression.c_str(), -1, SQLITE_STATIC);
-    while (sqlite3_step(stmt) == SQLITE_ROW) {
-      std::string expr = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
-      std::string reading = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
-      std::string definition_tags = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2));
-      std::string rules = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3));
-      std::string term_tags = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 5));
+  std::map<std::pair<std::string_view, std::string_view>, TermResult> term_map;
+  for (const auto& [name, styles, data] : dicts_) {
+    uint64_t hash = data->phf(expression);
+    uint64_t offset_addr = data->offsets[hash];
+    const uint8_t* index_addr = data->blobs + offset_addr;
+
+    uint32_t count = read_u32(index_addr);
+    for (uint32_t i = 0; i < count; i++) {
+      uint64_t offset = read_u64(index_addr);
+      const uint8_t* blob_addr = data->blobs + offset;
+
+      // first byte encodes term (0) or meta (1) entry
+      uint8_t type = read_u8(blob_addr);
+      if (type != 0) {
+        continue;
+      }
+
+      uint16_t expr_len = read_u16(blob_addr);
+      std::string_view expr = read_str(blob_addr, expr_len);
+
+      uint16_t reading_len = read_u16(blob_addr);
+      std::string_view reading = read_str(blob_addr, reading_len);
+
+      if (expr != expression && reading != expression) {
+        continue;
+      }
+
+      uint32_t glossary_size = read_u32(blob_addr);
+      std::string glossary = decompress_glossary(read_str(blob_addr, glossary_size).data(), glossary_size);
+
+      uint8_t def_tags_size = read_u8(blob_addr);
+      std::string_view definition_tags = read_str(blob_addr, def_tags_size);
+
+      uint8_t rules_size = read_u8(blob_addr);
+      std::string_view rules = read_str(blob_addr, rules_size);
+
+      uint8_t term_tag_size = read_u8(blob_addr);
+      std::string_view term_tags = read_str(blob_addr, term_tag_size);
 
       GlossaryEntry entry;
       entry.dict_name = name;
       entry.definition_tags = definition_tags;
       entry.term_tags = term_tags;
-
-      const void* blob = sqlite3_column_blob(stmt, 4);
-      int blob_size = sqlite3_column_bytes(stmt, 4);
-      entry.glossary = decompress_glossary(blob, blob_size);
+      entry.glossary = glossary;
 
       auto [it, inserted] = term_map.try_emplace({expr, reading});
       if (inserted) {
-        it->second = {.expression = expr,
-                      .reading = reading,
-                      .definition_tags = definition_tags,
-                      .rules = rules,
+        it->second = {.expression = std::string(expr),
+                      .reading = std::string(reading),
+                      .rules = std::string(rules),
                       .glossaries = {},
                       .frequencies = {}};
       } else {
-        if (!definition_tags.empty()) {
-          if (!it->second.definition_tags.empty()) {
-            it->second.definition_tags += " ";
-          }
-          it->second.definition_tags += definition_tags;
-        }
         if (!rules.empty()) {
           if (!it->second.rules.empty()) {
             it->second.rules += " ";
@@ -172,7 +206,6 @@ std::vector<TermResult> DictionaryQuery::query(const std::string& expression) co
       }
       it->second.glossaries.push_back(std::move(entry));
     }
-    sqlite3_reset(stmt);
   }
 
   auto results = term_map | std::views::values | std::views::as_rvalue | std::ranges::to<std::vector>();
@@ -184,14 +217,40 @@ std::vector<TermResult> DictionaryQuery::query(const std::string& expression) co
 
 void DictionaryQuery::query_freq(std::vector<TermResult>& terms) const {
   for (auto& term : terms) {
-    for (const auto& [name, styles, db, stmt] : freq_dicts_) {
-      sqlite3_bind_text(stmt, 1, term.expression.c_str(), -1, SQLITE_STATIC);
+    for (const auto& [name, styles, data] : freq_dicts_) {
+      uint64_t hash = data->phf(term.expression);
+      uint64_t offset_addr = data->offsets[hash];
+
+      const uint8_t* index_addr = data->blobs + offset_addr;
+      uint32_t count = read_u32(index_addr);
+
       std::vector<Frequency> frequencies;
-      while (sqlite3_step(stmt) == SQLITE_ROW) {
-        const char* data = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+      for (uint32_t i = 0; i < count; i++) {
+        uint64_t offset = read_u64(index_addr);
+        const uint8_t* blob_addr = data->blobs + offset;
+
+        uint8_t type = read_u8(blob_addr);
+        if (type != 1) {
+          continue;
+        }
+
+        uint16_t expr_len = read_u16(blob_addr);
+        std::string_view expr = read_str(blob_addr, expr_len);
+        if (expr != term.expression) {
+          continue;
+        }
+
+        uint8_t mode_len = read_u8(blob_addr);
+        std::string_view mode = read_str(blob_addr, mode_len);
+        if (mode != "freq") {
+          continue;
+        }
+
+        uint32_t freq_data_size = read_u32(blob_addr);
+        std::string_view freq_data = read_str(blob_addr, freq_data_size);
 
         ParsedFrequency parsed;
-        if (yomitan_parser::parse_frequency(data, parsed)) {
+        if (yomitan_parser::parse_frequency(freq_data, parsed)) {
           if (!parsed.reading.empty() && parsed.reading != term.reading) {
             continue;
           }
@@ -199,8 +258,6 @@ void DictionaryQuery::query_freq(std::vector<TermResult>& terms) const {
               Frequency{.value = parsed.value, .display_value = std::string(parsed.display_value)});
         }
       }
-      sqlite3_reset(stmt);
-
       if (!frequencies.empty()) {
         term.frequencies.emplace_back(FrequencyEntry{.dict_name = name, .frequencies = std::move(frequencies)});
       }
@@ -210,22 +267,46 @@ void DictionaryQuery::query_freq(std::vector<TermResult>& terms) const {
 
 void DictionaryQuery::query_pitch(std::vector<TermResult>& terms) const {
   for (auto& term : terms) {
-    for (const auto& [name, styles, db, stmt] : pitch_dicts_) {
-      sqlite3_bind_text(stmt, 1, term.expression.c_str(), -1, SQLITE_STATIC);
+    for (const auto& [name, styles, data] : pitch_dicts_) {
+      uint64_t hash = data->phf(term.expression);
+      uint64_t offset_addr = data->offsets[hash];
+
+      const uint8_t* index_addr = data->blobs + offset_addr;
+      uint32_t count = read_u32(index_addr);
+
       std::vector<int> pitch_positions;
-      while (sqlite3_step(stmt) == SQLITE_ROW) {
-        const char* data = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+      for (uint32_t i = 0; i < count; i++) {
+        uint64_t offset = read_u64(index_addr);
+        const uint8_t* blob_addr = data->blobs + offset;
+
+        uint8_t type = read_u8(blob_addr);
+        if (type != 1) {
+          continue;
+        }
+
+        uint16_t expr_len = read_u16(blob_addr);
+        std::string_view expr = read_str(blob_addr, expr_len);
+        if (expr != term.expression) {
+          continue;
+        }
+
+        uint8_t mode_len = read_u8(blob_addr);
+        std::string_view mode = read_str(blob_addr, mode_len);
+        if (mode != "pitch") {
+          continue;
+        }
+
+        uint32_t pitch_data_size = read_u32(blob_addr);
+        std::string_view pitch_data = read_str(blob_addr, pitch_data_size);
 
         ParsedPitch parsed;
-        if (yomitan_parser::parse_pitch(data, parsed)) {
+        if (yomitan_parser::parse_pitch(pitch_data, parsed)) {
           if (!parsed.reading.empty() && parsed.reading != term.reading) {
             continue;
           }
           pitch_positions.insert(pitch_positions.end(), parsed.pitches.begin(), parsed.pitches.end());
         }
       }
-      sqlite3_reset(stmt);
-
       if (!pitch_positions.empty()) {
         term.pitches.emplace_back(PitchEntry{.dict_name = name, .pitch_positions = std::move(pitch_positions)});
       }


### PR DESCRIPTION
### Import
branch `main`
```
manhhao@Mac build % ./benchmark-import jmdict.zip 10
dict: JMdict [2026-02-22] iterations: 10
term_count: 516633
media_count: 0
total: 8361.09ms
avg: 836.11ms
min: 827.25ms
max: 879.35ms
manhhao@Mac build % ./benchmark-import daijisen.zip 10
dict: 大辞泉 第二版 iterations: 10
term_count: 636269
media_count: 83
total: 35860.06ms
avg: 3586.01ms
min: 3531.80ms
max: 3745.90ms
manhhao@Mac build % ./benchmark-import vndb_characters_by_bee.zip 10
dict: VNDB Characters by Bee iterations: 10
term_count: 6648310
media_count: 146570
total: 157732.70ms
avg: 15773.27ms
min: 15282.80ms
max: 16149.59ms
```
branch `rm-sqlite`
```
manhhao@Mac build % ./benchmark-import jmdict.zip 10                
dict: JMdict [2026-02-22] iterations: 10
term_count: 516633
media_count: 0
total: 4085.56ms
avg: 408.56ms
min: 400.92ms
max: 427.10ms
manhhao@Mac build % ./benchmark-import daijisen.zip 10
dict: 大辞泉 第二版 iterations: 10
term_count: 636269
media_count: 83
total: 13424.24ms
avg: 1342.42ms
min: 1326.05ms
max: 1373.18ms
manhhao@Mac build % ./benchmark-import vndb_characters_by_bee.zip 10 
dict: VNDB Characters by Bee iterations: 10
term_count: 6648310
media_count: 146570
total: 80826.70ms
avg: 8082.67ms
min: 7841.13ms
max: 8148.76ms
```
### Lookup:
branch `main-benchmark`
```
manhhao@Mac build % ./benchmark-lookup JMdict\ \[2026-02-22\].db させられました 20000
word: させられました iterations: 20000
total: 25480.55ms
avg: 1.27ms
min: 1.19ms
max: 3.86ms
```
branch `rm-sqlite`
```
manhhao@Mac build % ./benchmark-lookup JMdict\ \[2026-02-22\] させられました 20000
word: させられました iterations: 20000
total: 19421.69ms
avg: 0.97ms
min: 0.94ms
max: 2.44ms
```