### PR TITLE
fix: accept numeric Yomitan term scores

### DIFF
--- a/src/json/yomitan_parser.hpp
+++ b/src/json/yomitan_parser.hpp
@@ -19,7 +19,7 @@ struct Term {
   std::string_view reading;
   std::optional<std::string_view> definition_tags;
   std::string_view rules;
-  int score = 0;
+  double score = 0;
   glz::raw_json_view glossary;
   int64_t sequence = 0;
   std::string_view term_tags;


### PR DESCRIPTION
## Summary

- Accept Yomitan term-bank scores represented as JSON numbers with a decimal form, such as `0.0`.
- Keeps the imported dictionary format unchanged; the score field is only parsed and is not written into the output blobs.

## Root Cause

Some Yomitan dictionaries serialize the term score column as `0.0`. The parser modeled `Term::score` as `int`, so Glaze rejected those term-bank rows. The importer then saw no parsed term or meta offsets and reported `empty dictionary`.

## Validation

- Compiled and ran a temporary parser check against a term row containing score `0.0`.
- Compiled and ran a temporary importer using the current source files against `[JA-EN] Living_Japanese_Slang_Dictionary_Scripting_Japan.zip`; import succeeded with `term_count: 636`.
- Ran `git diff --check`.

No test files were added per repository preference.
