### PR TITLE
feat: build summary on import

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -32,11 +32,11 @@ void cmd_import(const std::string& path) {
 
   if (result.success) {
     std::cout << std::format("title: {}\n", result.title);
-    std::cout << std::format("term_count: {}\n", result.term_count);
-    std::cout << std::format("meta_count: {}\n", result.meta_count);
-    std::cout << std::format("freq_count: {}\n", result.freq_count);
-    std::cout << std::format("pitch_count: {}\n", result.pitch_count);
-    std::cout << std::format("media_count: {}\n", result.media_count);
+    std::cout << std::format("term_count: {}\n", result.summary.counts.terms.total);
+    std::cout << std::format("meta_count: {}\n", result.summary.counts.termMeta["total"]);
+    std::cout << std::format("freq_count: {}\n", result.summary.counts.termMeta["freq"]);
+    std::cout << std::format("pitch_count: {}\n", result.summary.counts.termMeta["pitch"] + result.summary.counts.termMeta["ipa"]);
+    std::cout << std::format("media_count: {}\n", result.summary.counts.media.total);
   } else {
     std::cout << std::format("could not import dictionary:\n");
     for (const auto& error : result.errors) {

--- a/include/hoshidicts/importer.hpp
+++ b/include/hoshidicts/importer.hpp
@@ -1,11 +1,52 @@
 #pragma once
 
+#include <map>
+#include <optional>
 #include <string>
 #include <vector>
+
+struct SummaryItemCount {
+  size_t total = 0;
+};
+
+using SummaryMetaCount = std::map<std::string, size_t>;
+
+struct SummaryCounts {
+  SummaryItemCount terms;
+  SummaryMetaCount termMeta;
+  SummaryItemCount kanji;
+  SummaryMetaCount kanjiMeta;
+  SummaryItemCount tagMeta;
+  SummaryItemCount media;
+};
+
+struct Summary {
+  std::string title;
+  std::string revision;
+  bool sequenced = false;
+  std::optional<std::string> minimumYomitanVersion;
+  int version = 3;
+  uint64_t importDate = 0;
+  bool prefixWildcardsSupported = false;
+  SummaryCounts counts;
+  std::string styles;
+  std::optional<bool> isUpdatable;
+  std::optional<std::string> indexUrl;
+  std::optional<std::string> downloadUrl;
+  std::optional<std::string> author;
+  std::optional<std::string> url;
+  std::optional<std::string> description;
+  std::optional<std::string> attribution;
+  std::optional<std::string> sourceLanguage;
+  std::optional<std::string> targetLanguage;
+  std::optional<std::string> frequencyMode;
+  std::optional<bool> importSuccess;
+};
 
 struct ImportResult {
   bool success = false;
   std::string title;
+  Summary summary;
   size_t term_count = 0;
   size_t meta_count = 0;
   size_t freq_count = 0;

--- a/include/hoshidicts/importer.hpp
+++ b/include/hoshidicts/importer.hpp
@@ -47,11 +47,6 @@ struct ImportResult {
   bool success = false;
   std::string title;
   Summary summary;
-  size_t term_count = 0;
-  size_t meta_count = 0;
-  size_t freq_count = 0;
-  size_t pitch_count = 0;
-  size_t media_count = 0;
   std::vector<std::string> errors;
 };
 

--- a/src/importer.cpp
+++ b/src/importer.cpp
@@ -564,11 +564,6 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
     int styles_idx = zip.find("styles.css");
     if (styles_idx >= 0) {
       styles = zip.read(styles_idx);
-      if (!styles.empty()) {
-        std::ofstream styles_file(path + "/styles.css", std::ios::binary);
-        setup_stream_exceptions(styles_file);
-        styles_file.write(styles.data(), static_cast<std::streamsize>(styles.size()));
-      }
     }
 
     result.summary = create_summary(index, styles);

--- a/src/importer.cpp
+++ b/src/importer.cpp
@@ -43,8 +43,6 @@ struct ProcessedFile {
   std::vector<std::pair<uint64_t, uint64_t>> glossary_offsets;
   SummaryMetaCount meta_counts;
   size_t count = 0;
-  size_t pitch_count = 0;
-  size_t freq_count = 0;
 };
 
 void setup_stream_exceptions(std::ofstream& stream) { stream.exceptions(std::ios::failbit | std::ios::badbit); }
@@ -273,11 +271,6 @@ ProcessedFile process_meta_bank(const std::string& content) {
     processed.offsets.emplace_back(XXH3_64bits(expr.data(), expr.size()), offset);
     processed.count++;
     processed.meta_counts[std::string(mode)]++;
-    if (mode == "freq") {
-      processed.freq_count++;
-    } else if (mode == "pitch" || mode == "ipa") {
-      processed.pitch_count++;
-    }
   }
 
   processed.meta_counts["total"] = processed.count;
@@ -365,6 +358,8 @@ Summary create_summary(const Index& index, std::string styles) {
   summary.targetLanguage = copy_optional_string(index.targetLanguage);
   summary.frequencyMode = copy_optional_string(index.frequencyMode);
   summary.importSuccess = true;
+  summary.counts.termMeta["total"] = 0;
+  summary.counts.kanjiMeta["total"] = 0;
   return summary;
 }
 
@@ -408,7 +403,7 @@ void write_terms(std::ofstream& file, std::vector<std::pair<uint64_t, uint64_t>>
     }
 
     write_offset += processed.data.size();
-    result.term_count += processed.count;
+    result.summary.counts.terms.total += processed.count;
   };
 
   for (int file_index : files) {
@@ -447,9 +442,6 @@ void write_meta(std::ofstream& file, std::vector<std::pair<uint64_t, uint64_t>>&
     }
 
     write_offset += processed.data.size();
-    result.meta_count += processed.count;
-    result.freq_count += processed.freq_count;
-    result.pitch_count += processed.pitch_count;
     for (const auto& [mode, count] : processed.meta_counts) {
       result.summary.counts.termMeta[mode] += count;
     }
@@ -591,8 +583,6 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
     write_terms(blobs, offsets, zip, files.term_banks, write_offset, result, low_ram);
     write_meta(blobs, offsets, zip, files.meta_banks, write_offset, result, low_ram);
     count_unprocessed_banks(zip, files, result);
-    result.summary.counts.terms.total = result.term_count;
-    result.summary.counts.termMeta["total"] = result.meta_count;
     if (offsets.empty()) {
       throw std::runtime_error("empty dictionary");
     }
@@ -611,8 +601,7 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
     blobs.write(offset_buf.data(), static_cast<std::streamsize>(offset_buf.size()));
     hash_thread.get();
 
-    result.media_count = media_thread.get();
-    result.summary.counts.media.total = result.media_count;
+    result.summary.counts.media.total = media_thread.get();
 
     if (glz::write_file_json(result.summary, path + "/index.json", std::string{})) {
       throw std::runtime_error("failed to write index.json");

--- a/src/importer.cpp
+++ b/src/importer.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -29,6 +30,8 @@ namespace {
 struct Files {
   std::vector<int> term_banks;
   std::vector<int> meta_banks;
+  std::vector<int> kanji_banks;
+  std::vector<int> kanji_meta_banks;
   std::vector<int> tag_banks;
   std::vector<int> media_files;
 };
@@ -38,6 +41,7 @@ struct ProcessedFile {
   std::vector<std::pair<uint64_t, uint64_t>> offsets;
   ankerl::unordered_dense::map<uint64_t, std::vector<char>> glossaries;
   std::vector<std::pair<uint64_t, uint64_t>> glossary_offsets;
+  SummaryMetaCount meta_counts;
   size_t count = 0;
   size_t pitch_count = 0;
   size_t freq_count = 0;
@@ -57,6 +61,10 @@ Files get_files(const Zip& zip) {
       files.term_banks.push_back(i);
     } else if (name.starts_with("term_meta_bank_")) {
       files.meta_banks.push_back(i);
+    } else if (name.starts_with("kanji_bank_")) {
+      files.kanji_banks.push_back(i);
+    } else if (name.starts_with("kanji_meta_bank_")) {
+      files.kanji_meta_banks.push_back(i);
     } else if (name.starts_with("tag_bank_")) {
       files.tag_banks.push_back(i);
     } else if (!(name == "styles.css" || name == "index.json")) {
@@ -264,6 +272,7 @@ ProcessedFile process_meta_bank(const std::string& content) {
 
     processed.offsets.emplace_back(XXH3_64bits(expr.data(), expr.size()), offset);
     processed.count++;
+    processed.meta_counts[std::string(mode)]++;
     if (mode == "freq") {
       processed.freq_count++;
     } else if (mode == "pitch" || mode == "ipa") {
@@ -271,7 +280,92 @@ ProcessedFile process_meta_bank(const std::string& content) {
     }
   }
 
+  processed.meta_counts["total"] = processed.count;
   return processed;
+}
+
+size_t count_json_array(const std::string& content) {
+  if (content.empty()) {
+    return 0;
+  }
+
+  std::vector<glz::raw_json> entries;
+  if (glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = false}>(entries, content)) {
+    return 0;
+  }
+  return entries.size();
+}
+
+SummaryMetaCount count_meta_modes(const std::string& content) {
+  SummaryMetaCount counts{{"total", 0}};
+  if (content.empty()) {
+    return counts;
+  }
+
+  std::vector<Meta> entries;
+  if (!yomitan_parser::parse_meta_bank(content, entries)) {
+    return counts;
+  }
+
+  for (const auto& entry : entries) {
+    counts[std::string(entry.mode)]++;
+    counts["total"]++;
+  }
+  return counts;
+}
+
+void count_unprocessed_banks(const Zip& zip, const Files& files, ImportResult& result) {
+  for (int file_index : files.kanji_banks) {
+    result.summary.counts.kanji.total += count_json_array(zip.read(file_index));
+  }
+
+  for (int file_index : files.kanji_meta_banks) {
+    SummaryMetaCount modes = count_meta_modes(zip.read(file_index));
+    for (const auto& [name, count] : modes) {
+      result.summary.counts.kanjiMeta[name] += count;
+    }
+  }
+
+  for (int file_index : files.tag_banks) {
+    result.summary.counts.tagMeta.total += count_json_array(zip.read(file_index));
+  }
+}
+
+template <typename T>
+std::optional<std::string> copy_optional_string(T value) {
+  if (!value.has_value()) {
+    return std::nullopt;
+  }
+  return std::string(*value);
+}
+
+uint64_t unix_time_ms() {
+  const auto now = std::chrono::system_clock::now().time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+}
+
+Summary create_summary(const Index& index, std::string styles) {
+  Summary summary;
+  summary.title = std::string(index.title);
+  summary.revision = std::string(index.revision);
+  summary.sequenced = index.sequenced;
+  summary.minimumYomitanVersion = copy_optional_string(index.minimumYomitanVersion);
+  summary.version = index.version.value_or(index.format.value_or(3));
+  summary.importDate = unix_time_ms();
+  summary.prefixWildcardsSupported = false;
+  summary.styles = std::move(styles);
+  summary.isUpdatable = index.isUpdatable;
+  summary.indexUrl = copy_optional_string(index.indexUrl);
+  summary.downloadUrl = copy_optional_string(index.downloadUrl);
+  summary.author = copy_optional_string(index.author);
+  summary.url = copy_optional_string(index.url);
+  summary.description = copy_optional_string(index.description);
+  summary.attribution = copy_optional_string(index.attribution);
+  summary.sourceLanguage = copy_optional_string(index.sourceLanguage);
+  summary.targetLanguage = copy_optional_string(index.targetLanguage);
+  summary.frequencyMode = copy_optional_string(index.frequencyMode);
+  summary.importSuccess = true;
+  return summary;
 }
 
 void write_terms(std::ofstream& file, std::vector<std::pair<uint64_t, uint64_t>>& offsets, const Zip& zip,
@@ -356,6 +450,9 @@ void write_meta(std::ofstream& file, std::vector<std::pair<uint64_t, uint64_t>>&
     result.meta_count += processed.count;
     result.freq_count += processed.freq_count;
     result.pitch_count += processed.pitch_count;
+    for (const auto& [mode, count] : processed.meta_counts) {
+      result.summary.counts.termMeta[mode] += count;
+    }
   };
 
   for (int file_index : files) {
@@ -471,13 +568,10 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
     std::string path = dict_path.string();
     std::filesystem::create_directories(dict_path);
 
-    if (glz::write_file_json(index, path + "/index.json", std::string{})) {
-      throw std::runtime_error("failed to write index.json");
-    }
-
+    std::string styles;
     int styles_idx = zip.find("styles.css");
     if (styles_idx >= 0) {
-      std::string styles = zip.read(styles_idx);
+      styles = zip.read(styles_idx);
       if (!styles.empty()) {
         std::ofstream styles_file(path + "/styles.css", std::ios::binary);
         setup_stream_exceptions(styles_file);
@@ -485,6 +579,7 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
       }
     }
 
+    result.summary = create_summary(index, styles);
     const Files files = get_files(zip);
     std::future<size_t> media_thread =
         std::async(std::launch::async, [&path, &zip, &files]() { return write_media(path, zip, files.media_files); });
@@ -495,6 +590,9 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
     uint64_t write_offset = 0;
     write_terms(blobs, offsets, zip, files.term_banks, write_offset, result, low_ram);
     write_meta(blobs, offsets, zip, files.meta_banks, write_offset, result, low_ram);
+    count_unprocessed_banks(zip, files, result);
+    result.summary.counts.terms.total = result.term_count;
+    result.summary.counts.termMeta["total"] = result.meta_count;
     if (offsets.empty()) {
       throw std::runtime_error("empty dictionary");
     }
@@ -514,11 +612,19 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
     hash_thread.get();
 
     result.media_count = media_thread.get();
+    result.summary.counts.media.total = result.media_count;
+
+    if (glz::write_file_json(result.summary, path + "/index.json", std::string{})) {
+      throw std::runtime_error("failed to write index.json");
+    }
 
     std::ofstream sui(path + "/.hoshidicts_3", std::ios::binary);
     result.success = true;
   } catch (const std::exception& e) {
     result.success = false;
+    if (!result.summary.title.empty()) {
+      result.summary.importSuccess = false;
+    }
     result.errors.emplace_back(e.what());
   }
 

--- a/src/json/yomitan_parser.cpp
+++ b/src/json/yomitan_parser.cpp
@@ -7,9 +7,13 @@ template <>
 struct glz::meta<Index> {
   using T = Index;
   static constexpr auto value =
-      object("title", glz::raw_string<&T::title>, "revision", glz::raw_string<&T::revision>, "format", &T::format,
-             "isUpdatable", &T::isUpdatable, "indexUrl", glz::raw_string<&T::indexUrl>, "downloadUrl",
-             glz::raw_string<&T::downloadUrl>);
+      object("title", glz::raw_string<&T::title>, "format", &T::format, "version", &T::version,
+             "revision", glz::raw_string<&T::revision>, "minimumYomitanVersion", glz::raw_string<&T::minimumYomitanVersion>,
+             "sequenced", &T::sequenced, "isUpdatable", &T::isUpdatable, "indexUrl", glz::raw_string<&T::indexUrl>,
+             "downloadUrl", glz::raw_string<&T::downloadUrl>, "author", glz::raw_string<&T::author>,
+             "url", glz::raw_string<&T::url>, "description", glz::raw_string<&T::description>,
+             "attribution", glz::raw_string<&T::attribution>, "sourceLanguage", glz::raw_string<&T::sourceLanguage>,
+             "targetLanguage", glz::raw_string<&T::targetLanguage>, "frequencyMode", glz::raw_string<&T::frequencyMode>);
 };
 
 template <>

--- a/src/json/yomitan_parser.hpp
+++ b/src/json/yomitan_parser.hpp
@@ -1,17 +1,27 @@
 #pragma once
 #include <cstdint>
 #include <glaze/glaze.hpp>
-#include <cstdint>
+#include <optional>
 #include <string_view>
 #include <vector>
 
 struct Index {
   std::string_view title;
-  int format = 3;
+  std::optional<int> format;
+  std::optional<int> version;
   std::string_view revision;
-  bool isUpdatable;
-  std::string_view indexUrl;
-  std::string_view downloadUrl;
+  std::optional<std::string_view> minimumYomitanVersion;
+  bool sequenced = false;
+  std::optional<bool> isUpdatable;
+  std::optional<std::string_view> indexUrl;
+  std::optional<std::string_view> downloadUrl;
+  std::optional<std::string_view> author;
+  std::optional<std::string_view> url;
+  std::optional<std::string_view> description;
+  std::optional<std::string_view> attribution;
+  std::optional<std::string_view> sourceLanguage;
+  std::optional<std::string_view> targetLanguage;
+  std::optional<std::string_view> frequencyMode;
 };
 
 struct Term {

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -81,7 +81,7 @@ void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
   Dictionary dict;
   Summary summary;
   std::string buf{};
-  if (glz::read_file_json(summary, path + "/index.json", buf)) {
+  if (glz::read_file_json<glz::opts{.error_on_unknown_keys = false}>(summary, path + "/index.json", buf)) {
     return;
   }
 

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -1,4 +1,5 @@
 #include "hoshidicts/query.hpp"
+#include "hoshidicts/importer.hpp"
 
 #include <ankerl/unordered_dense.h>
 #include <zstd.h>
@@ -78,14 +79,15 @@ void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
   }
 
   Dictionary dict;
-  Index index;
+  Summary summary;
   std::string buf{};
-  if (glz::read_file_json(index, path + "/index.json", buf)) {
+  if (glz::read_file_json(summary, path + "/index.json", buf)) {
     return;
   }
 
-  dict.name = index.title.empty() ? std::filesystem::path(path).stem().string() : index.title;
-  if (std::filesystem::exists(path + "/styles.css")) {
+  dict.name = summary.title.empty() ? std::filesystem::path(path).stem().string() : summary.title;
+  dict.styles = summary.styles;
+  if (dict.styles.empty() && std::filesystem::exists(path + "/styles.css")) {
     std::ifstream f(path + "/styles.css");
     dict.styles = std::string(std::istreambuf_iterator<char>(f), {});
   }


### PR DESCRIPTION
i wanted to show the "details" information that yomitan shows for dictionaries in aidoku, but the import result did not contain this information. i checked yomitan and tried to get all the same info when importing ([reference](https://github.com/yomidevs/yomitan/blob/master/ext/js/dictionary/dictionary-importer.js))

changes:
- adds `DictionarySummary` to `ImportResult` that matches [this yomitan type](https://github.com/yomidevs/yomitan/blob/c0c3702963c22e0f39fdd2f03deef6b15558a7f5/types/ext/dictionary-importer.d.ts#L46)
- updates `Index` to match [the yomitan type](https://github.com/yomidevs/yomitan/blob/c0c3702963c22e0f39fdd2f03deef6b15558a7f5/types/ext/dictionary-data.d.ts#L24)
    - removes the hardcoded `format` 3 (idk if this should be kept) and makes `isUpdatable`, `indexUrl`, and `downloadUrl` optional
- counts everything for the summary
    - this includes counts from kanji banks, which aren't being actually processed outside of this (not sure if this is necessary)
    - kinda makes the separate counts on the `ImportResult` redundant, so maybe it would be better if they were removed and the summary counts were just used, but the `pitch_count` is special since these are just treated as term meta counts in the summary
- writes the summary to`index.json` in the import result directory instead of the original index
    - if this should be a new summary.json(?) file instead lmk, but it contains essentially the same info
    - this probably breaks `DictionaryIndex` in hoshi reader which e.g. expects the format property and a non-optional indexUrl. idk if this means the `.hoshidicts_3` number should be bumped?
- uses styles in index.json if they exist instead of loading styles.css during query

haven't used cpp in years so apologies if i did something wrong