### PR TITLE
fix: use native filesystem paths for UTF-8 dictionary paths

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -6,6 +6,7 @@
 #include <ranges>
 #include <string>
 
+#include "../src/path_utils.hpp"
 #include "../src/text_processor/text_processor.hpp"
 #include "hoshidicts/deinflector.hpp"
 #include "hoshidicts/importer.hpp"
@@ -24,8 +25,8 @@ void print_usage(const char* program) {
 }
 
 void cmd_import(const std::string& path) {
-  std::filesystem::path zip_path(path);
-  std::string output_dir = zip_path.parent_path().string();
+  std::filesystem::path zip_path = path_utils::from_utf8(path);
+  std::string output_dir = path_utils::to_utf8(zip_path.parent_path());
   if (output_dir.empty()) {
     output_dir = ".";
   }
@@ -36,7 +37,8 @@ void cmd_import(const std::string& path) {
     std::cout << std::format("term_count: {}\n", result.summary.counts.terms.total);
     std::cout << std::format("meta_count: {}\n", result.summary.counts.termMeta["total"]);
     std::cout << std::format("freq_count: {}\n", result.summary.counts.termMeta["freq"]);
-    std::cout << std::format("pitch_count: {}\n", result.summary.counts.termMeta["pitch"] + result.summary.counts.termMeta["ipa"]);
+    std::cout << std::format("pitch_count: {}\n",
+                             result.summary.counts.termMeta["pitch"] + result.summary.counts.termMeta["ipa"]);
     std::cout << std::format("kanji_count: {}\n", result.summary.counts.kanji.total);
     std::cout << std::format("media_count: {}\n", result.summary.counts.media.total);
   } else {

--- a/include/hoshidicts/importer.hpp
+++ b/include/hoshidicts/importer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <optional>
 #include <string>

--- a/src/hash/bloom.cpp
+++ b/src/hash/bloom.cpp
@@ -24,7 +24,7 @@ bool bloom::load(const uint8_t* ptr, size_t size) {
   return true;
 }
 
-void bloom::build_to_file(const std::vector<uint64_t>& hashes, const std::string& path) {
+void bloom::build_to_file(const std::vector<uint64_t>& hashes, const std::filesystem::path& path) {
   uint64_t num_bits = std::bit_ceil(std::max<uint64_t>(hashes.size() * 10, 64));
   uint64_t mask = num_bits - 1;
 

--- a/src/hash/bloom.hpp
+++ b/src/hash/bloom.hpp
@@ -1,12 +1,12 @@
 #pragma once
 #include <cstdint>
-#include <string>
+#include <filesystem>
 #include <vector>
 
 namespace hash {
 class bloom {
  public:
-  static void build_to_file(const std::vector<uint64_t>& hashes, const std::string& path);
+  static void build_to_file(const std::vector<uint64_t>& hashes, const std::filesystem::path& path);
   bool load(const uint8_t* ptr, size_t size);
 
   bool contains(uint64_t h) const {

--- a/src/hash/hash.cpp
+++ b/src/hash/hash.cpp
@@ -32,7 +32,8 @@ uint64_t linear::operator()(std::string_view key) const {
   }
 }
 
-void linear::build_to_file(const std::vector<std::pair<uint64_t, uint64_t>>& hash_entries, const std::string& path) {
+void linear::build_to_file(const std::vector<std::pair<uint64_t, uint64_t>>& hash_entries,
+                           const std::filesystem::path& path) {
   ptr_->capacity = std::max<uint64_t>(hash_entries.size() * 10 / 7, 16);
   size_t file_size = sizeof(uint32_t) + ptr_->capacity * sizeof(slot);
 
@@ -40,7 +41,7 @@ void linear::build_to_file(const std::vector<std::pair<uint64_t, uint64_t>>& has
   if (!out) {
     throw std::runtime_error("failed to create hash table");
   }
- 
+
   std::memcpy(out.data, &ptr_->capacity, sizeof(uint32_t));
   ptr_->table = reinterpret_cast<slot*>(out.data + sizeof(uint32_t));
   std::memset(ptr_->table, 0, ptr_->capacity * sizeof(slot));

--- a/src/hash/hash.hpp
+++ b/src/hash/hash.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <cstdint>
+#include <filesystem>
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "bloom.hpp"
@@ -13,7 +13,7 @@ class linear {
   ~linear();
   uint64_t operator()(std::string_view key) const;
 
-  void build_to_file(const std::vector<std::pair<uint64_t, uint64_t>>& hash_entries, const std::string& path);
+  void build_to_file(const std::vector<std::pair<uint64_t, uint64_t>>& hash_entries, const std::filesystem::path& path);
   bool load(uint8_t* ptr, size_t size);
   void set_bloom(const bloom* b) { bloom_ = b; }
 

--- a/src/importer.cpp
+++ b/src/importer.cpp
@@ -24,6 +24,7 @@
 #include "hash/bloom.hpp"
 #include "hash/hash.hpp"
 #include "json/yomitan_parser.hpp"
+#include "path_utils.hpp"
 #include "zip/zip.hpp"
 
 namespace {
@@ -571,13 +572,13 @@ std::vector<char> build_offset_index(std::vector<std::pair<uint64_t, uint64_t>>&
   return offset_buf;
 }
 
-size_t write_media(const std::string& path, const Zip& zip, const std::vector<int>& files) {
+size_t write_media(const std::filesystem::path& path, const Zip& zip, const std::vector<int>& files) {
   if (files.empty()) {
     return 0;
   }
 
-  std::ofstream media(path + "/media.bin", std::ios::binary);
-  std::ofstream media_idx(path + "/media.idx", std::ios::binary);
+  std::ofstream media(path / "media.bin", std::ios::binary);
+  std::ofstream media_idx(path / "media.idx", std::ios::binary);
   setup_stream_exceptions(media);
   setup_stream_exceptions(media_idx);
 
@@ -618,9 +619,12 @@ size_t write_media(const std::string& path, const Zip& zip, const std::vector<in
 
 ImportResult dictionary_importer::import(const std::string& zip_path, const std::string& output_dir, bool low_ram) {
   ImportResult result;
+  std::filesystem::path dict_path;
   try {
+    const std::filesystem::path native_zip_path = path_utils::from_utf8(zip_path);
+    const std::filesystem::path native_output_dir = path_utils::from_utf8(output_dir);
     Zip zip;
-    if (!zip.open(zip_path)) {
+    if (!zip.open(native_zip_path)) {
       throw std::runtime_error("failed to open zip");
     }
 
@@ -640,8 +644,7 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
 
     result.title = index.title;
 
-    std::filesystem::path dict_path = std::filesystem::path(output_dir) / result.title;
-    std::string path = dict_path.string();
+    dict_path = native_output_dir / path_utils::from_utf8(result.title);
     std::filesystem::create_directories(dict_path);
 
     std::string styles;
@@ -652,10 +655,10 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
 
     result.summary = create_summary(index, styles);
     const Files files = get_files(zip);
-    std::future<size_t> media_thread =
-        std::async(std::launch::async, [&path, &zip, &files]() { return write_media(path, zip, files.media_files); });
+    std::future<size_t> media_thread = std::async(
+        std::launch::async, [&dict_path, &zip, &files]() { return write_media(dict_path, zip, files.media_files); });
 
-    std::ofstream blobs(path + "/blobs.bin", std::ios::binary);
+    std::ofstream blobs(dict_path / "blobs.bin", std::ios::binary);
     setup_stream_exceptions(blobs);
     std::vector<std::pair<uint64_t, uint64_t>> offsets;
     uint64_t write_offset = 0;
@@ -671,11 +674,11 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
     auto offset_buf = build_offset_index(offsets, write_offset, hash_entries);
     std::vector<std::pair<uint64_t, uint64_t>>().swap(offsets);
 
-    auto hash_thread = std::async(std::launch::async, [&hash_entries, &path]() {
+    auto hash_thread = std::async(std::launch::async, [&hash_entries, &dict_path]() {
       hash::linear table;
-      table.build_to_file(hash_entries, path + "/hash.table");
+      table.build_to_file(hash_entries, dict_path / "hash.table");
       auto hashes = hash_entries | std::views::keys | std::ranges::to<std::vector>();
-      hash::bloom::build_to_file(hashes, path + "/bloom.filter");
+      hash::bloom::build_to_file(hashes, dict_path / "bloom.filter");
     });
 
     blobs.write(offset_buf.data(), static_cast<std::streamsize>(offset_buf.size()));
@@ -683,11 +686,15 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
 
     result.summary.counts.media.total = media_thread.get();
 
-    if (glz::write_file_json(result.summary, path + "/index.json", std::string{})) {
+    std::string summary_json;
+    if (glz::write_json(result.summary, summary_json)) {
       throw std::runtime_error("failed to write index.json");
     }
+    std::ofstream index_file(dict_path / "index.json", std::ios::binary);
+    setup_stream_exceptions(index_file);
+    index_file.write(summary_json.data(), static_cast<std::streamsize>(summary_json.size()));
 
-    std::ofstream sui(path + "/.hoshidicts_3", std::ios::binary);
+    std::ofstream sui(dict_path / ".hoshidicts_3", std::ios::binary);
     result.success = true;
   } catch (const std::exception& e) {
     result.success = false;
@@ -697,8 +704,9 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
     result.error = e.what();
   }
 
-  if (!result.success && !result.title.empty()) {
-    std::filesystem::remove_all(std::filesystem::path(output_dir) / result.title);
+  if (!result.success && !dict_path.empty()) {
+    std::error_code error;
+    std::filesystem::remove_all(dict_path, error);
   }
 
   return result;

--- a/src/memory/memory.cpp
+++ b/src/memory/memory.cpp
@@ -10,10 +10,10 @@
 #endif
 
 namespace memory {
-mapped_file map_rd(const std::string& path) {
+mapped_file map_rd(const std::filesystem::path& path) {
 #ifdef _WIN32
   HANDLE file =
-      CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+      CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
   if (file == INVALID_HANDLE_VALUE) {
     return {};
   }
@@ -24,7 +24,7 @@ mapped_file map_rd(const std::string& path) {
     return {};
   }
 
-  HANDLE mapping = CreateFileMappingA(file, nullptr, PAGE_READONLY, 0, 0, nullptr);
+  HANDLE mapping = CreateFileMappingW(file, nullptr, PAGE_READONLY, 0, 0, nullptr);
   CloseHandle(file);
   if (!mapping) {
     return {};
@@ -43,7 +43,7 @@ mapped_file map_rd(const std::string& path) {
     return {};
   }
 
-  struct stat st {};
+  struct stat st{};
   if (fstat(fd, &st) != 0 || st.st_size == 0) {
     close(fd);
     return {};
@@ -59,14 +59,14 @@ mapped_file map_rd(const std::string& path) {
 #endif
 }
 
-mapped_file map_rw(const std::string& path, size_t file_size) {
+mapped_file map_rw(const std::filesystem::path& path, size_t file_size) {
   if (file_size == 0) {
     return {};
   }
 
 #ifdef _WIN32
-  HANDLE file = CreateFileA(path.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL,
-                            nullptr);
+  HANDLE file = CreateFileW(path.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
+                            FILE_ATTRIBUTE_NORMAL, nullptr);
   if (file == INVALID_HANDLE_VALUE) {
     return {};
   }
@@ -78,7 +78,7 @@ mapped_file map_rw(const std::string& path, size_t file_size) {
     return {};
   }
 
-  HANDLE mapping = CreateFileMappingA(file, nullptr, PAGE_READWRITE, size.HighPart, size.LowPart, nullptr);
+  HANDLE mapping = CreateFileMappingW(file, nullptr, PAGE_READWRITE, size.HighPart, size.LowPart, nullptr);
   CloseHandle(file);
   if (!mapping) {
     return {};

--- a/src/memory/memory.hpp
+++ b/src/memory/memory.hpp
@@ -2,7 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <string>
+#include <filesystem>
 
 namespace memory {
 struct mapped_file {
@@ -12,7 +12,7 @@ struct mapped_file {
   explicit operator bool() const { return data != nullptr; }
 };
 
-mapped_file map_rd(const std::string& path);
-mapped_file map_rw(const std::string& path, size_t file_size);
+mapped_file map_rd(const std::filesystem::path& path);
+mapped_file map_rw(const std::filesystem::path& path, size_t file_size);
 void unmap(mapped_file mapping);
 }

--- a/src/path_utils.hpp
+++ b/src/path_utils.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+namespace path_utils {
+inline std::filesystem::path from_utf8(std::string_view value) {
+  return std::filesystem::path(std::u8string(reinterpret_cast<const char8_t*>(value.data()), value.size()));
+}
+
+inline std::string to_utf8(const std::filesystem::path& value) {
+  const std::u8string encoded = value.u8string();
+  return {reinterpret_cast<const char*>(encoded.data()), encoded.size()};
+}
+}

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -1,5 +1,4 @@
 #include "hoshidicts/query.hpp"
-#include "hoshidicts/importer.hpp"
 
 #include <ankerl/unordered_dense.h>
 #include <zstd.h>
@@ -16,8 +15,10 @@
 #include <vector>
 
 #include "hash/hash.hpp"
+#include "hoshidicts/importer.hpp"
 #include "json/yomitan_parser.hpp"
 #include "memory/memory.hpp"
+#include "path_utils.hpp"
 
 namespace {
 template <typename T>
@@ -66,13 +67,14 @@ DictionaryQuery::Dictionary::~Dictionary() = default;
 DictionaryQuery::Dictionary::Dictionary(Dictionary&&) noexcept = default;
 DictionaryQuery::Dictionary& DictionaryQuery::Dictionary::operator=(Dictionary&&) noexcept = default;
 
-void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
+void DictionaryQuery::add_dict(const std::string& path_utf8, DictionaryType type) {
+  const std::filesystem::path path = path_utils::from_utf8(path_utf8);
   int version = 0;
-  if (std::filesystem::is_regular_file(path + "/.hoshidicts_3")) {
+  if (std::filesystem::is_regular_file(path / ".hoshidicts_3")) {
     version = 3;
-  } else if (std::filesystem::is_regular_file(path + "/.hoshidicts_2")) {
+  } else if (std::filesystem::is_regular_file(path / ".hoshidicts_2")) {
     version = 2;
-  } else if (std::filesystem::is_regular_file(path + "/.hoshidicts_1")) {
+  } else if (std::filesystem::is_regular_file(path / ".hoshidicts_1")) {
     version = 1;
   } else {
     return;
@@ -80,22 +82,26 @@ void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
 
   Dictionary dict;
   Summary summary;
-  std::string buf{};
-  if (glz::read_file_json<glz::opts{.error_on_unknown_keys = false}>(summary, path + "/index.json", buf)) {
+  std::ifstream index_file(path / "index.json", std::ios::binary);
+  if (!index_file) {
+    return;
+  }
+  std::string buf(std::istreambuf_iterator<char>(index_file), {});
+  if (glz::read<glz::opts{.error_on_unknown_keys = false}>(summary, buf)) {
     return;
   }
 
-  dict.name = summary.title.empty() ? std::filesystem::path(path).stem().string() : summary.title;
+  dict.name = summary.title.empty() ? path_utils::to_utf8(path.stem()) : summary.title;
   dict.styles = summary.styles;
-  if (dict.styles.empty() && std::filesystem::exists(path + "/styles.css")) {
-    std::ifstream f(path + "/styles.css");
+  if (dict.styles.empty() && std::filesystem::exists(path / "styles.css")) {
+    std::ifstream f(path / "styles.css");
     dict.styles = std::string(std::istreambuf_iterator<char>(f), {});
   }
 
   dict.data = std::make_unique<DictionaryData>();
   dict.data->version = version;
 
-  dict.data->hash_table = memory::map_rd(path + "/hash.table");
+  dict.data->hash_table = memory::map_rd(path / "hash.table");
   if (!dict.data->hash_table) {
     return;
   }
@@ -103,7 +109,7 @@ void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
     return;
   }
 
-  dict.data->bloom_filter = memory::map_rd(path + "/bloom.filter");
+  dict.data->bloom_filter = memory::map_rd(path / "bloom.filter");
   if (!dict.data->bloom_filter) {
     return;
   }
@@ -112,14 +118,14 @@ void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
   }
   dict.data->table.set_bloom(&dict.data->bloom);
 
-  dict.data->blobs = memory::map_rd(path + "/blobs.bin");
+  dict.data->blobs = memory::map_rd(path / "blobs.bin");
   if (!dict.data->blobs) {
     return;
   }
 
-  dict.data->media = memory::map_rd(path + "/media.bin");
+  dict.data->media = memory::map_rd(path / "media.bin");
   if (dict.data->media) {
-    dict.data->media_index = memory::map_rd(path + "/media.idx");
+    dict.data->media_index = memory::map_rd(path / "media.idx");
   }
 
   switch (type) {

--- a/src/zip/zip.cpp
+++ b/src/zip/zip.cpp
@@ -16,11 +16,9 @@ T read_at(const uint8_t* base, size_t offset) {
 }
 }
 
-Zip::~Zip() {
-  memory::unmap(file);
-}
+Zip::~Zip() { memory::unmap(file); }
 
-bool Zip::open(const std::string& path) {
+bool Zip::open(const std::filesystem::path& path) {
   file = memory::map_rd(path);
   if (!file) {
     return false;

--- a/src/zip/zip.hpp
+++ b/src/zip/zip.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <filesystem>
 #include <optional>
 #include <string>
 #include <vector>
@@ -20,7 +21,7 @@ struct Zip {
   std::vector<ZipEntry> entries;
 
   ~Zip();
-  bool open(const std::string& path);
+  bool open(const std::filesystem::path& path);
   int find(const std::string& name) const;
   std::string read(int index) const;
 


### PR DESCRIPTION
On Windows, `std::filesystem::path`'s narrow-string constructor interprets bytes in the active code page, not UTF-8. The public API takes UTF-8 paths (`hd_import`, `hd_query_add_*_dict`, `Importer`/`DictionaryQuery`), so those bytes get reinterpreted as ANSI the moment they become a `path`. Any dictionary under a path containing non-ASCII characters — a Japanese folder name, an accented username — fails to open.

## Change

Add `src/path_utils.hpp` (16 lines) to convert explicitly at the boundary:

```cpp
inline std::filesystem::path from_utf8(std::string_view value) {
  return std::filesystem::path(std::u8string(reinterpret_cast<const char8_t*>(value.data()), value.size()));
}
inline std::string to_utf8(const std::filesystem::path& value);
```

The `u8string` overload is defined to treat its input as UTF-8, so this pins the interpretation instead of inheriting the code page.

Then convert exactly once per public entry point and thread `std::filesystem::path` through the internals so the bytes are never reinterpreted again:

- `memory::map_rd` / `map_rw`, `Zip::open`, `hash::linear::build_to_file`, `hash::bloom::build_to_file` — `const std::string&` → `const std::filesystem::path&`
- conversions at `Importer::import`, `DictionaryQuery::add_dict`, and the CLI

No behaviour change on POSIX, where the narrow constructor already takes UTF-8 bytes.

## Verification

GCC 14.4.0 / CMake 3.31.6 / Ninja, Release, `-DHOSHIDICTS_CLI=ON`: 0 errors, 0 warnings, `libhoshidicts.a` + `hoshidicts-cli` + `hoshidicts-cli-c` all link.

I can't reproduce the Windows failure on Linux — by construction the bug only exists where the native narrow encoding isn't UTF-8. So treat the Windows behaviour claim as resting on the `path` constructor semantics above rather than on a test I ran. These changes are what GameSentenceMiner currently ships in its Windows builds against this library.

## Note on #21

This includes the same one-line `#include <cstdint>` fix as #21, because `importer.hpp` is touched here anyway. Either can land first; if #21 goes in, this rebases cleanly.
