### PR TITLE
fix: include cstdint for uint64_t in importer.hpp

### DIFF
--- a/include/hoshidicts/importer.hpp
+++ b/include/hoshidicts/importer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <optional>
 #include <string>


### PR DESCRIPTION
`include/hoshidicts/importer.hpp` declares `Summary::importDate` as `uint64_t` but never includes `<cstdint>`. It currently compiles only when that type arrives transitively through another standard header, and with GCC 14's libstdc++ it no longer does — so `main` fails to build:

```
/include/hoshidicts/importer.hpp:29:3: error: 'uint64_t' does not name a type
   29 |   uint64_t importDate = 0;
      |   ^~~~~~~~
/src/importer.cpp:392:11: error: 'struct Summary' has no member named 'importDate'
```

The second error is a cascade of the first.

## Fix

Add `#include <cstdint>`. One line, no behaviour change.

## Verification

GCC 14.4.0 / CMake 3.31.6 / Ninja, `-DCMAKE_BUILD_TYPE=Release`, submodules at their pinned commits:

| | result |
|---|---|
| `main` @ 6240e06 | 2 errors, `ninja: build stopped: subcommand failed` |
| this branch | `libhoshidicts.a` links, 0 errors |

## Note

`size_t` in the same header is also used without `<cstddef>` and resolves transitively today. I left it alone to keep the diff minimal — happy to include it if you'd rather fix both at once.

For downstream consumers this removes the need for `-include cstdint` / `/FIcstdint` build workarounds.
