### PR TITLE
fix: bound kanji query materialization

### DIFF
--- a/src/query.cpp
+++ b/src/query.cpp
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <memory>
 #include <ranges>
+#include <stdexcept>
 #include <string_view>
 #include <vector>
 
@@ -20,6 +21,33 @@
 #include "memory/memory.hpp"
 
 namespace {
+constexpr size_t MAX_KANJI_RESULT_ENTRIES = 64;
+constexpr size_t MAX_KANJI_RESULT_STRINGS = 4096;
+constexpr size_t MAX_KANJI_RESULT_BYTES = 256 * 1024;
+
+class KanjiResultBudget {
+ public:
+  void claim_entry() {
+    if (entries_ >= MAX_KANJI_RESULT_ENTRIES) {
+      throw std::length_error("kanji query exceeded the entry limit");
+    }
+    ++entries_;
+  }
+
+  void claim_string(std::string_view value) {
+    if (strings_ >= MAX_KANJI_RESULT_STRINGS || value.size() > MAX_KANJI_RESULT_BYTES - bytes_) {
+      throw std::length_error("kanji query exceeded the aggregate string limit");
+    }
+    ++strings_;
+    bytes_ += value.size();
+  }
+
+ private:
+  size_t entries_ = 0;
+  size_t strings_ = 0;
+  size_t bytes_ = 0;
+};
+
 template <typename T>
 T read_val(const uint8_t*& addr) {
   T val;
@@ -376,6 +404,8 @@ void DictionaryQuery::query_pitch(std::vector<TermResult>& terms) const {
 KanjiResult DictionaryQuery::query_kanji(const std::string& kanji) const {
   KanjiResult result;
   result.character = kanji;
+  KanjiResultBudget budget;
+  budget.claim_string(kanji);
 
   for (const auto& [name, styles, data] : kanji_dicts_) {
     uint64_t offset_addr = data->table(kanji);
@@ -409,6 +439,12 @@ KanjiResult DictionaryQuery::query_kanji(const std::string& kanji) const {
       auto tags_len = read_val<uint16_t>(blob_addr);
       std::string_view tags = read_str(blob_addr, tags_len);
 
+      budget.claim_entry();
+      budget.claim_string(name);
+      budget.claim_string(onyomi);
+      budget.claim_string(kunyomi);
+      budget.claim_string(tags);
+
       KanjiEntry entry;
       entry.dict_name = name;
       entry.onyomi = onyomi;
@@ -419,6 +455,7 @@ KanjiResult DictionaryQuery::query_kanji(const std::string& kanji) const {
       for (uint16_t j = 0; j < def_count; j++) {
         auto def_len = read_val<uint16_t>(blob_addr);
         std::string_view def = read_str(blob_addr, def_len);
+        budget.claim_string(def);
         entry.definitions.emplace_back(def);
       }
 
@@ -428,6 +465,8 @@ KanjiResult DictionaryQuery::query_kanji(const std::string& kanji) const {
         std::string_view key = read_str(blob_addr, key_len);
         auto val_len = read_val<uint16_t>(blob_addr);
         std::string_view val = read_str(blob_addr, val_len);
+        budget.claim_string(key);
+        budget.claim_string(val);
         entry.stats.emplace(key, val);
       }
 


### PR DESCRIPTION
`DictionaryQuery::query_kanji` sizes all of its work from values read out of the dictionary blob:

```cpp
auto count = read_val<uint32_t>(index_addr);   // entry count, straight from the file
for (uint32_t i = 0; i < count; i++) {
  ...
  auto def_len = read_val<uint16_t>(blob_addr);
  std::string_view def = read_str(blob_addr, def_len);
  entry.definitions.emplace_back(def);          // copied into an owned std::string
```

The entry count, the per-entry definition and stat counts, and every string length are all file-controlled, and each string is copied into an owned `std::string`. A corrupt or deliberately crafted kanji dictionary can therefore make a single `query_kanji` call allocate without bound.

## Change

A `KanjiResultBudget` claimed before each materialization, with three limits:

| limit | value |
|---|---|
| entries | 64 |
| strings | 4096 |
| aggregate string bytes | 256 KiB |

Sized to sit far above real data — a KANJIDIC character is a handful of readings plus a few dozen definitions and stats.

## Two things worth your call

**The budget is shared across all installed kanji dictionaries**, since `kanji_dicts_` is the outer loop. Someone with many kanji dictionaries installed for the same character reaches the limits sooner than someone with one. That seemed right to me — the point is to bound one call's total allocation — but it does mean the limits are per-query, not per-dictionary.

**It signals by throwing `std::length_error`.** If you'd rather not throw across the library boundary, I'm happy to change it to return a truncated `KanjiResult`, or to surface an error code. Tell me which you prefer and I'll rework it.

## Verification

GCC 14.4.0 / CMake 3.31.6 / Ninja, `-DCMAKE_BUILD_TYPE=Release`: builds clean, 0 errors, 0 warnings.

Built with `-include cstdint` since `main` currently needs #21 to compile at all.
