### PR TITLE
fix: normalize kana width before script conversion

### DIFF
--- a/src/text_processor/text_processor.cpp
+++ b/src/text_processor/text_processor.cpp
@@ -276,6 +276,11 @@ std::u32string numbers_to_kanji(const std::u32string& text) {
 // TODO: implement rest of preprocessors
 std::vector<TextProcessor> get_japanese_processors() {
   return {
+      // Width and combining-character normalization must run before script
+      // conversion so half-width katakana can also produce a hiragana variant.
+      // Yomitan applies these normalizers before convertHiraganaToKatakana.
+      {.options = {0, 1},
+       .process = [](const std::u32string& text, int opt) -> std::u32string { return opt == 1 ? nfkc(text) : text; }},
       // https://github.com/yomidevs/yomitan/blob/81d17d877fb18c62ba826210bf6db2b7f4d4deed/ext/js/language/ja/japanese-text-preprocessors.js#L66
       {.options = {0, 1, 2},
        .process = [](const std::u32string& text, int opt) -> std::u32string {
@@ -299,8 +304,6 @@ std::vector<TextProcessor> get_japanese_processors() {
              return text;
          }
        }},
-      {.options = {0, 1},
-       .process = [](const std::u32string& text, int opt) -> std::u32string { return opt == 1 ? nfkc(text) : text; }},
       {.options = {0, 1},
        .process = [](const std::u32string& text, int opt) -> std::u32string {
          return opt == 1 ? alphanumeric_to_fullwidth(text) : text;

--- a/src/text_processor/text_processor.cpp
+++ b/src/text_processor/text_processor.cpp
@@ -276,9 +276,6 @@ std::u32string numbers_to_kanji(const std::u32string& text) {
 // TODO: implement rest of preprocessors
 std::vector<TextProcessor> get_japanese_processors() {
   return {
-      // Width and combining-character normalization must run before script
-      // conversion so half-width katakana can also produce a hiragana variant.
-      // Yomitan applies these normalizers before convertHiraganaToKatakana.
       {.options = {0, 1},
        .process = [](const std::u32string& text, int opt) -> std::u32string { return opt == 1 ? nfkc(text) : text; }},
       // https://github.com/yomidevs/yomitan/blob/81d17d877fb18c62ba826210bf6db2b7f4d4deed/ext/js/language/ja/japanese-text-preprocessors.js#L66


### PR DESCRIPTION
Half-width katakana does not produce a hiragana variant, so `ﾜｶﾞﾊｲ` fails to match a `わがはい` entry that the full-width form `ワガハイ` matches fine.

## Cause

In `get_japanese_processors()` the NFKC processor — which is what folds half-width kana to full-width — is registered *after* the hiragana/katakana converter. By the time the converter runs, the half-width form hasn't been normalized yet, so no hiragana variant is ever generated for it.

Yomitan orders these the other way around. From `ext/js/language/language-descriptors.js`, the Japanese entry:

```js
textPreprocessors: {
    convertHalfWidthCharacters,
    alphabeticToHiragana,
    normalizeCombiningCharacters,
    normalizeCJKCompatibilityCharacters,
    normalizeRadicalCharacters,
    alphanumericWidthVariants,
    convertHiraganaToKatakana,      // <- after all the normalizers
    collapseEmphaticSequences,
    standardizeKanji,
},
```

`convertHalfWidthCharacters`, `normalizeCombiningCharacters` and `normalizeCJKCompatibilityCharacters` — all three of which `nfkc()` covers here — run before `convertHiraganaToKatakana`.

## Change

Move the NFKC processor to the front of the list. Pure reordering; no processor is added or removed.

## Verification

Probe against `text_processor::process`, same build both times (GCC 14.4, Release):

```cpp
for (auto&& v : text_processor::process(input))
  if (v.text == "わがはい") found = true;
```

| input | `main` @ 6240e06 | this branch |
|---|---|---|
| `ﾜｶﾞﾊｲ` (half-width) | **NO** | **YES** |
| `ワガハイ` (full-width) | YES | YES |
| `わがはい` (hiragana) | YES | YES |

Full library also builds clean, 0 errors, 0 warnings.

## No test included

There's no test infrastructure in the tree to add one to, and I didn't want to introduce a harness inside a behaviour fix. Happy to add coverage in whatever shape you'd prefer, separately.

Built with `-include cstdint` since `main` currently needs #21 to compile.
