### PR TITLE
build: set /utf-8 for MSVC so UTF-8 literals survive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,12 @@ target_link_libraries(hoshidicts PRIVATE
     utf8proc::utf8proc
 )
 
+if(MSVC)
+    # deinflector.cpp and text_processor.cpp hold UTF-8 literals and carry no BOM,
+    # so MSVC would otherwise read them as the system code page.
+    target_compile_options(hoshidicts PRIVATE /utf-8)
+endif()
+
 if(HOSHIDICTS_CLI)
     add_executable(hoshidicts-cli
         cli/main.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,8 +58,6 @@ target_link_libraries(hoshidicts PRIVATE
 )
 
 if(MSVC)
-    # deinflector.cpp and text_processor.cpp hold UTF-8 literals and carry no BOM,
-    # so MSVC would otherwise read them as the system code page.
     target_compile_options(hoshidicts PRIVATE /utf-8)
 endif()
 


### PR DESCRIPTION
`src/deinflector.cpp` and `src/text_processor/text_processor.cpp` contain UTF-8 encoded narrow string literals and carry no BOM:

| file | lines with non-ASCII bytes | first 3 bytes |
|---|---|---|
| `src/deinflector.cpp` | 983 | `2f 2f 20` (`// `) |
| `src/text_processor/text_processor.cpp` | 11 | `23 69 6e` (`#in`) |

With no BOM and no `/utf-8`, MSVC reads both as the active code page instead of UTF-8, so those literals are corrupted on any machine whose ACP is not UTF-8. `/utf-8` sets the source *and* execution character sets, so they are read and stored as written.

Scoped `PRIVATE` to the `hoshidicts` target — only its own sources contain non-ASCII bytes, and the public headers are ASCII-only, so consumers do not inherit the flag.

### On `/Zc:__cplusplus`

I deliberately left it out. Nothing in this repository reads the *value* of `__cplusplus` — the only occurrences are the `extern "C"` guards in `include/hoshidicts_c.h`, which are value-independent. The one bare check in a vendored dependency (`external/glaze/include/glaze/json/schema.hpp:1033`) degrades gracefully rather than failing. So I could not justify the flag from anything actually in the tree.

### Verification

I do not have MSVC, so I have **not** compiled this on Windows — the claim above is from the byte-level encoding of the sources plus documented MSVC behaviour, not from a build. What I did verify is that the change is inert elsewhere: GCC 14.4 Release configures and builds clean (0 errors, 0 warnings) with the `if(MSVC)` guard in place.

Note the GCC build needs `-include cstdint` until #21 lands.