### PR TITLE
feat: widen frequency values to double and allow no display value

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -107,7 +107,7 @@ void cmd_freq(const std::string& path, const std::string& expression, const std:
   for (auto& freq : terms[0].frequencies) {
     std::cout << std::format("dict: {}\n", freq.dict_name);
     for (auto& freq_entry : freq.frequencies) {
-      std::cout << std::format("val: {} display_val: {}\n", freq_entry.value, freq_entry.display_value);
+      std::cout << std::format("val: {} display_val: {}\n", freq_entry.value, freq_entry.display_value.value_or("<null>"));
       count++;
     }
   }

--- a/include/hoshidicts/lookup.hpp
+++ b/include/hoshidicts/lookup.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "deinflector.hpp"
@@ -14,11 +16,21 @@ struct LookupResult {
   int preprocessor_steps;
 };
 
+enum class LookupFrequencyOrder { Auto, Ascending, Descending, Disabled };
+
+struct LookupOptions {
+  std::optional<std::string_view> primary_reading;
+  std::optional<std::string_view> frequency_dictionary;
+  LookupFrequencyOrder frequency_order = LookupFrequencyOrder::Auto;
+};
+
 class Lookup {
  public:
   Lookup(DictionaryQuery& query, Deinflector& deinflector) : query_(query), deinflector_(deinflector) {};
   std::vector<LookupResult> lookup(const std::string& lookup_string, int max_results = 16,
                                    size_t scan_length = 16) const;
+  std::vector<LookupResult> lookup(const std::string& lookup_string, int max_results, size_t scan_length,
+                                   const LookupOptions& options) const;
 
  private:
   static void filter_by_pos(std::vector<TermResult>& terms, const DeinflectionResult& d);

--- a/include/hoshidicts/query.hpp
+++ b/include/hoshidicts/query.hpp
@@ -14,8 +14,8 @@
 #endif
 
 struct Frequency {
-  int value;
-  std::string display_value;
+  double value;
+  std::optional<std::string> display_value;
 };
 
 struct DictionaryStyle {

--- a/include/hoshidicts/query.hpp
+++ b/include/hoshidicts/query.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <unordered_map>
 
 #if defined(__clang__) && defined(__APPLE__)
 #define SWIFT_IMPORT_UNSAFE __attribute__((swift_attr("import_unsafe")))
@@ -112,6 +113,7 @@ class DictionaryQuery {
   void materialize(TermResult& term) const;
 
   struct DictionaryData;
+  enum class FrequencyMode { Rank, Occurrence };
   struct Dictionary {
     Dictionary();
     ~Dictionary();
@@ -129,8 +131,13 @@ class DictionaryQuery {
   enum DictionaryType : uint8_t { TERM, FREQ, PITCH, KANJI };
 
   void add_dict(const std::string& path, DictionaryType);
+  static std::vector<Frequency> query_frequencies(const DictionaryData& data, const std::string& expression,
+                                                  std::optional<std::string_view> reading);
+  static FrequencyMode infer_frequency_mode(const DictionaryData& data,
+                                            const std::optional<std::string>& source_language);
 
   static std::string decompress_glossary(const void* data, size_t size);
+  FrequencyMode primary_frequency_mode_ = FrequencyMode::Rank;
   std::vector<Dictionary> term_dicts_;
   std::vector<Dictionary> freq_dicts_;
   std::vector<Dictionary> pitch_dicts_;

--- a/include/hoshidicts_c.h
+++ b/include/hoshidicts_c.h
@@ -43,8 +43,11 @@ typedef struct hd_kanji_results hd_kanji_results;
 typedef struct hd_styles hd_styles;
 
 typedef struct hd_frequency {
-  int32_t value;
+  double value;
   hd_str display_value;
+  // Distinguishes an archive that supplied no display value from one that
+  // supplied an empty string.
+  int display_value_is_null;
 } hd_frequency;
 
 typedef struct hd_dictionary_style {

--- a/include/hoshidicts_c.h
+++ b/include/hoshidicts_c.h
@@ -155,11 +155,31 @@ typedef struct hd_lookup_result {
   int32_t preprocessor_steps;
 } hd_lookup_result;
 
+typedef enum hd_lookup_frequency_order {
+  HD_LOOKUP_FREQUENCY_ORDER_AUTO = 0,
+  HD_LOOKUP_FREQUENCY_ORDER_ASCENDING = 1,
+  HD_LOOKUP_FREQUENCY_ORDER_DESCENDING = 2,
+  HD_LOOKUP_FREQUENCY_ORDER_DISABLED = 3,
+} hd_lookup_frequency_order;
+
+// A null hd_str leaves the corresponding preference unset.
+typedef struct hd_lookup_options {
+  hd_str primary_reading;
+  hd_str frequency_dictionary;
+  int32_t frequency_order;
+} hd_lookup_options;
+
 hd_lookup* hd_lookup_new(hd_query* q, hd_deinflector* d);
 void hd_lookup_free(hd_lookup* l);
 
 hd_lookup_results* hd_lookup_run(const hd_lookup* l, const char* lookup_string, int max_results, size_t scan_length,
                                  const hd_lookup_result** out_results, size_t* out_count);
+// As hd_lookup_run, but applies the caller's sort preferences before the
+// max_results cap, so the cap keeps the results the caller would have ranked
+// highest. Passing a null options pointer is equivalent to hd_lookup_run.
+hd_lookup_results* hd_lookup_run_with_options(const hd_lookup* l, const char* lookup_string, int max_results,
+                                              size_t scan_length, const hd_lookup_options* options,
+                                              const hd_lookup_result** out_results, size_t* out_count);
 void hd_lookup_results_free(hd_lookup_results* r);
 
 #ifdef __cplusplus

--- a/src/hoshidicts_c.cpp
+++ b/src/hoshidicts_c.cpp
@@ -168,7 +168,10 @@ static void build_frequencies(std::vector<hd_frequency_entry>& entries, std::vec
 
     size_t frequencies_start = frequencies.size();
     for (const auto& freq : freq_entry.frequencies) {
-      frequencies.push_back(hd_frequency{freq.value, hd_str{freq.display_value.c_str(), freq.display_value.size()}});
+      const bool is_null = !freq.display_value.has_value();
+      const hd_str display =
+          is_null ? hd_str{nullptr, 0} : hd_str{freq.display_value->c_str(), freq.display_value->size()};
+      frequencies.push_back(hd_frequency{freq.value, display, static_cast<int>(is_null)});
     }
     frq.frequencies = frequencies.data() + frequencies_start;
     frq.frequencies_count = freq_entry.frequencies.size();

--- a/src/hoshidicts_c.cpp
+++ b/src/hoshidicts_c.cpp
@@ -2,6 +2,9 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string_view>
 
 #include "hoshidicts/deinflector.hpp"
 #include "hoshidicts/importer.hpp"
@@ -365,66 +368,126 @@ hd_lookup* hd_lookup_new(hd_query* q, hd_deinflector* d) {
 
 void hd_lookup_free(hd_lookup* l) { delete l; }
 
+static void marshal_lookup_results(hd_lookup_results* r) {
+  size_t trace_count = 0;
+  size_t glossaries_count = 0;
+  size_t freq_entry_count = 0;
+  size_t freq_count = 0;
+  size_t pitch_entry_count = 0;
+  size_t pitch_count = 0;
+  size_t transcription_count = 0;
+  for (const auto& lookup_result : r->res) {
+    trace_count += lookup_result.trace.size();
+    glossaries_count += lookup_result.term.glossaries.size();
+    freq_entry_count += lookup_result.term.frequencies.size();
+    pitch_entry_count += lookup_result.term.pitches.size();
+    for (const auto& freq_entry : lookup_result.term.frequencies) {
+      freq_count += freq_entry.frequencies.size();
+    }
+    for (const auto& pitch_entry : lookup_result.term.pitches) {
+      pitch_count += pitch_entry.pitches.size();
+      transcription_count += pitch_entry.transcriptions.size();
+    }
+  }
+  r->trace.reserve(trace_count);
+  r->glossary_entries.reserve(glossaries_count);
+  r->frequency_entries.reserve(freq_entry_count);
+  r->frequencies.reserve(freq_count);
+  r->pitch_entries.reserve(pitch_entry_count);
+  r->pitches.reserve(pitch_count);
+  r->transcriptions.reserve(transcription_count);
+
+  for (const auto& lookup_result : r->res) {
+    const auto& term_result = lookup_result.term;
+    hd_lookup_result lr;
+    lr.matched = hd_str{lookup_result.matched.c_str(), lookup_result.matched.size()};
+    lr.deinflected = hd_str{lookup_result.deinflected.c_str(), lookup_result.deinflected.size()};
+    lr.preprocessor_steps = lookup_result.preprocessor_steps;
+
+    size_t trace_start = r->trace.size();
+    for (const auto& group : lookup_result.trace) {
+      r->trace.push_back(hd_transform_group{hd_str{group.name.c_str(), group.name.size()},
+                                            hd_str{group.description.c_str(), group.description.size()}});
+    }
+    lr.trace = r->trace.data() + trace_start;
+    lr.trace_count = lookup_result.trace.size();
+
+    lr.term.expression = hd_str{term_result.expression.c_str(), term_result.expression.size()};
+    lr.term.reading = hd_str{term_result.reading.c_str(), term_result.reading.size()};
+    lr.term.rules = hd_str{term_result.rules.c_str(), term_result.rules.size()};
+    lr.term.score = term_result.score;
+
+    build_glossaries(r->glossary_entries, term_result, lr.term);
+    build_frequencies(r->frequency_entries, r->frequencies, term_result, lr.term);
+    build_pitches(r->pitch_entries, r->pitches, r->transcriptions, term_result, lr.term);
+
+    r->results.push_back(lr);
+  }
+}
+
 hd_lookup_results* hd_lookup_run(const hd_lookup* l, const char* lookup_string, int max_results, size_t scan_length,
                                  const hd_lookup_result** out_results, size_t* out_count) {
   try {
     auto r = std::make_unique<hd_lookup_results>();
     r->res = l->lookup.lookup(lookup_string, max_results, scan_length);
+    marshal_lookup_results(r.get());
 
-    size_t trace_count = 0;
-    size_t glossaries_count = 0;
-    size_t freq_entry_count = 0;
-    size_t freq_count = 0;
-    size_t pitch_entry_count = 0;
-    size_t pitch_count = 0;
-    size_t transcription_count = 0;
-    for (const auto& lookup_result : r->res) {
-      trace_count += lookup_result.trace.size();
-      glossaries_count += lookup_result.term.glossaries.size();
-      freq_entry_count += lookup_result.term.frequencies.size();
-      pitch_entry_count += lookup_result.term.pitches.size();
-      for (const auto& freq_entry : lookup_result.term.frequencies) {
-        freq_count += freq_entry.frequencies.size();
-      }
-      for (const auto& pitch_entry : lookup_result.term.pitches) {
-        pitch_count += pitch_entry.pitches.size();
-        transcription_count += pitch_entry.transcriptions.size();
+    *out_results = r->results.data();
+    *out_count = r->results.size();
+    return r.release();
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+// An empty hd_str means "unset"; a non-empty one with a null pointer is a
+// caller error rather than an empty preference.
+static std::optional<std::string_view> optional_string_view(hd_str value) {
+  if (value.len == 0) {
+    return std::nullopt;
+  }
+  if (value.ptr == nullptr) {
+    throw std::invalid_argument("non-empty lookup option has a null pointer");
+  }
+  return std::string_view(value.ptr, value.len);
+}
+
+hd_lookup_results* hd_lookup_run_with_options(const hd_lookup* l, const char* lookup_string, int max_results,
+                                              size_t scan_length, const hd_lookup_options* options,
+                                              const hd_lookup_result** out_results, size_t* out_count) {
+  if (l == nullptr || lookup_string == nullptr || out_results == nullptr || out_count == nullptr || max_results <= 0 ||
+      scan_length == 0) {
+    return nullptr;
+  }
+  *out_results = nullptr;
+  *out_count = 0;
+
+  try {
+    LookupOptions native_options;
+    if (options != nullptr) {
+      native_options.primary_reading = optional_string_view(options->primary_reading);
+      native_options.frequency_dictionary = optional_string_view(options->frequency_dictionary);
+      switch (options->frequency_order) {
+        case HD_LOOKUP_FREQUENCY_ORDER_AUTO:
+          native_options.frequency_order = LookupFrequencyOrder::Auto;
+          break;
+        case HD_LOOKUP_FREQUENCY_ORDER_ASCENDING:
+          native_options.frequency_order = LookupFrequencyOrder::Ascending;
+          break;
+        case HD_LOOKUP_FREQUENCY_ORDER_DESCENDING:
+          native_options.frequency_order = LookupFrequencyOrder::Descending;
+          break;
+        case HD_LOOKUP_FREQUENCY_ORDER_DISABLED:
+          native_options.frequency_order = LookupFrequencyOrder::Disabled;
+          break;
+        default:
+          return nullptr;
       }
     }
-    r->trace.reserve(trace_count);
-    r->glossary_entries.reserve(glossaries_count);
-    r->frequency_entries.reserve(freq_entry_count);
-    r->frequencies.reserve(freq_count);
-    r->pitch_entries.reserve(pitch_entry_count);
-    r->pitches.reserve(pitch_count);
-    r->transcriptions.reserve(transcription_count);
 
-    for (const auto& lookup_result : r->res) {
-      const auto& term_result = lookup_result.term;
-      hd_lookup_result lr;
-      lr.matched = hd_str{lookup_result.matched.c_str(), lookup_result.matched.size()};
-      lr.deinflected = hd_str{lookup_result.deinflected.c_str(), lookup_result.deinflected.size()};
-      lr.preprocessor_steps = lookup_result.preprocessor_steps;
-
-      size_t trace_start = r->trace.size();
-      for (const auto& group : lookup_result.trace) {
-        r->trace.push_back(hd_transform_group{hd_str{group.name.c_str(), group.name.size()},
-                                              hd_str{group.description.c_str(), group.description.size()}});
-      }
-      lr.trace = r->trace.data() + trace_start;
-      lr.trace_count = lookup_result.trace.size();
-
-      lr.term.expression = hd_str{term_result.expression.c_str(), term_result.expression.size()};
-      lr.term.reading = hd_str{term_result.reading.c_str(), term_result.reading.size()};
-      lr.term.rules = hd_str{term_result.rules.c_str(), term_result.rules.size()};
-      lr.term.score = term_result.score;
-
-      build_glossaries(r->glossary_entries, term_result, lr.term);
-      build_frequencies(r->frequency_entries, r->frequencies, term_result, lr.term);
-      build_pitches(r->pitch_entries, r->pitches, r->transcriptions, term_result, lr.term);
-
-      r->results.push_back(lr);
-    }
+    auto r = std::make_unique<hd_lookup_results>();
+    r->res = l->lookup.lookup(lookup_string, max_results, scan_length, native_options);
+    marshal_lookup_results(r.get());
 
     *out_results = r->results.data();
     *out_count = r->results.size();

--- a/src/json/yomitan_parser.cpp
+++ b/src/json/yomitan_parser.cpp
@@ -1,5 +1,9 @@
 #include "yomitan_parser.hpp"
 
+#include <charconv>
+#include <cmath>
+#include <regex>
+#include <string>
 #include <string_view>
 #include <variant>
 
@@ -7,13 +11,13 @@ template <>
 struct glz::meta<Index> {
   using T = Index;
   static constexpr auto value =
-      object("title", glz::raw_string<&T::title>, "format", &T::format, "version", &T::version,
-             "revision", glz::raw_string<&T::revision>, "minimumYomitanVersion", glz::raw_string<&T::minimumYomitanVersion>,
+      object("title", glz::raw_string<&T::title>, "format", &T::format, "version", &T::version, "revision",
+             glz::raw_string<&T::revision>, "minimumYomitanVersion", glz::raw_string<&T::minimumYomitanVersion>,
              "sequenced", &T::sequenced, "isUpdatable", &T::isUpdatable, "indexUrl", glz::raw_string<&T::indexUrl>,
-             "downloadUrl", glz::raw_string<&T::downloadUrl>, "author", glz::raw_string<&T::author>,
-             "url", glz::raw_string<&T::url>, "description", glz::raw_string<&T::description>,
-             "attribution", glz::raw_string<&T::attribution>, "sourceLanguage", glz::raw_string<&T::sourceLanguage>,
-             "targetLanguage", glz::raw_string<&T::targetLanguage>, "frequencyMode", glz::raw_string<&T::frequencyMode>);
+             "downloadUrl", glz::raw_string<&T::downloadUrl>, "author", glz::raw_string<&T::author>, "url",
+             glz::raw_string<&T::url>, "description", glz::raw_string<&T::description>, "attribution",
+             glz::raw_string<&T::attribution>, "sourceLanguage", glz::raw_string<&T::sourceLanguage>, "targetLanguage",
+             glz::raw_string<&T::targetLanguage>, "frequencyMode", glz::raw_string<&T::frequencyMode>);
 };
 
 template <>
@@ -33,8 +37,9 @@ struct glz::meta<Meta> {
 template <>
 struct glz::meta<Kanji> {
   using T = Kanji;
-  static constexpr auto value = array(glz::raw_string<&T::character>, glz::raw_string<&T::onyomi>,
-                                      glz::raw_string<&T::kunyomi>, glz::raw_string<&T::tags>, &T::definitions, &T::stats);
+  static constexpr auto value =
+      array(glz::raw_string<&T::character>, glz::raw_string<&T::onyomi>, glz::raw_string<&T::kunyomi>,
+            glz::raw_string<&T::tags>, &T::definitions, &T::stats);
 };
 
 template <>
@@ -46,19 +51,19 @@ struct glz::meta<Tag> {
 
 namespace internal {
 struct FrequencyValue {
-  int value;
+  double value;
   std::optional<std::string> display_value;
 };
 
 struct RawFrequencyFlat {
   std::optional<std::string_view> reading;
-  int value;
+  double value;
   std::optional<std::string> display_value;
 };
 
 struct RawFrequency {
   std::optional<std::string_view> reading;
-  std::variant<int, FrequencyValue> frequency;
+  std::variant<double, std::string, FrequencyValue> frequency;
 };
 
 struct PitchesArray {
@@ -150,42 +155,87 @@ bool yomitan_parser::parse_tag_bank(std::string_view content, std::vector<Tag>& 
 }
 
 bool yomitan_parser::parse_frequency(std::string_view content, ParsedFrequency& out) {
-  internal::RawFrequencyFlat parsed_flat;
-  auto error =
-      glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = true}>(parsed_flat, content);
-  if (!error) {
-    out.reading = parsed_flat.reading.value_or("");
-    out.value = parsed_flat.value;
-    out.display_value = parsed_flat.display_value.value_or(std::to_string(parsed_flat.value));
-    return true;
-  }
+  auto parse_string_number = [](const std::string& value) {
+    // Keep this in sync with Yomitan's Translator._numberRegex.
+    static const std::regex number_regex(R"([+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?)");
+    std::smatch match;
+    if (!std::regex_search(value, match, number_regex)) {
+      return 0.0;
+    }
 
-  int val;
-  error = glz::read_json(val, content);
-  if (!error) {
-    out.value = val;
-    out.display_value = std::to_string(val);
-    out.reading = "";
+    double parsed = 0;
+    const std::string matched = match.str();
+    const char* begin = matched.data();
+    const char* end = begin + matched.size();
+    if (begin != end && *begin == '+') {
+      begin++;
+    }
+    const auto result = std::from_chars(begin, end, parsed);
+    return result.ec == std::errc{} && result.ptr == end && std::isfinite(parsed) ? parsed : 0.0;
+  };
+
+  auto assign_value = [&](const auto& value) {
+    using T = std::decay_t<decltype(value)>;
+    if constexpr (std::is_same_v<T, double>) {
+      if (!std::isfinite(value)) {
+        return false;
+      }
+      out.value = value;
+      out.display_value = std::nullopt;
+    } else if constexpr (std::is_same_v<T, std::string>) {
+      out.value = parse_string_number(value);
+      out.display_value = value;
+    } else {
+      if (!std::isfinite(value.value)) {
+        return false;
+      }
+      out.value = value.value;
+      out.display_value = value.display_value;
+    }
     return true;
-  }
+  };
 
   internal::RawFrequency parsed;
-  error = glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = true}>(parsed, content);
-  if (error) {
-    return false;
+  auto error = glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = true}>(parsed, content);
+  if (!error) {
+    out.reading = parsed.reading;
+    return std::visit(assign_value, parsed.frequency);
   }
 
-  out.reading = parsed.reading.value_or("");
-  if (std::holds_alternative<int>(parsed.frequency)) {
-    int freq = std::get<int>(parsed.frequency);
-    out.value = freq;
-    out.display_value = std::to_string(freq);
-  } else {
-    auto& freq = std::get<internal::FrequencyValue>(parsed.frequency);
-    out.value = freq.value;
-    out.display_value = freq.display_value.value_or(std::to_string(freq.value));
+  internal::RawFrequencyFlat parsed_flat;
+  error = glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = true}>(parsed_flat, content);
+  if (!error) {
+    if (!std::isfinite(parsed_flat.value)) {
+      return false;
+    }
+    out.reading = parsed_flat.reading;
+    out.value = parsed_flat.value;
+    out.display_value = parsed_flat.display_value;
+    return true;
   }
-  return true;
+
+  double val;
+  error = glz::read_json(val, content);
+  if (!error) {
+    if (!std::isfinite(val)) {
+      return false;
+    }
+    out.value = val;
+    out.display_value = std::nullopt;
+    out.reading = std::nullopt;
+    return true;
+  }
+
+  std::string string_value;
+  error = glz::read_json(string_value, content);
+  if (!error) {
+    out.reading = std::nullopt;
+    out.value = parse_string_number(string_value);
+    out.display_value = std::move(string_value);
+    return true;
+  }
+
+  return false;
 }
 
 bool yomitan_parser::parse_pitch(std::string_view content, ParsedPitch& out) {
@@ -226,7 +276,7 @@ bool yomitan_parser::parse_ipa(std::string_view content, ParsedPitch& out) {
   }
 
   out.reading = parsed.reading;
-  out.transcriptions =
-      parsed.transcriptions | std::views::transform(&internal::TranscriptionsArray::ipa) | std::ranges::to<std::vector>();
+  out.transcriptions = parsed.transcriptions | std::views::transform(&internal::TranscriptionsArray::ipa) |
+                       std::ranges::to<std::vector>();
   return true;
 }

--- a/src/json/yomitan_parser.hpp
+++ b/src/json/yomitan_parser.hpp
@@ -59,9 +59,9 @@ struct Tag {
 };
 
 struct ParsedFrequency {
-  std::string_view reading;
-  int value;
-  std::string display_value;
+  std::optional<std::string_view> reading;
+  double value = 0;
+  std::optional<std::string> display_value;
 };
 
 struct ParsedAccent {

--- a/src/lookup.cpp
+++ b/src/lookup.cpp
@@ -3,8 +3,8 @@
 #include <utf8.h>
 
 #include <algorithm>
-#include <climits>
 #include <map>
+#include <optional>
 #include <ranges>
 #include <sstream>
 
@@ -21,26 +21,30 @@ std::vector<std::string> split_whitespace(const std::string& str) {
   return result;
 }
 
-int get_freq_value_for_dict(const TermResult& term, const std::string& dict_name) {
+std::optional<int> get_freq_value_for_dict(const TermResult& term, std::string_view dictionary_name, bool descending) {
+  std::optional<int> frequency;
   for (const auto& frequency_entry : term.frequencies) {
-    if (frequency_entry.dict_name != dict_name) {
+    if (frequency_entry.dict_name != dictionary_name || frequency_entry.frequencies.empty()) {
       continue;
     }
 
-    int min_frequency = INT_MAX;
-    for (const auto& frequency : frequency_entry.frequencies) {
-      if (frequency.value >= 0) {
-        min_frequency = std::min(min_frequency, frequency.value);
-      }
+    for (const auto& candidate : frequency_entry.frequencies) {
+      frequency = frequency.has_value() ? std::optional<int>(descending ? std::max(*frequency, candidate.value)
+                                                                       : std::min(*frequency, candidate.value))
+                                        : std::optional<int>(candidate.value);
     }
-    return min_frequency;
   }
 
-  return INT_MAX;
+  return frequency;
 }
 }
 
 std::vector<LookupResult> Lookup::lookup(const std::string& lookup_string, int max_results, size_t scan_length) const {
+  return lookup(lookup_string, max_results, scan_length, LookupOptions{});
+}
+
+std::vector<LookupResult> Lookup::lookup(const std::string& lookup_string, int max_results, size_t scan_length,
+                                         const LookupOptions& options) const {
   std::map<std::pair<std::string, std::string>, LookupResult> result_map;
 
   size_t text_len = utf8::distance(lookup_string.begin(), lookup_string.end());
@@ -87,52 +91,98 @@ std::vector<LookupResult> Lookup::lookup(const std::string& lookup_string, int m
   }
 
   auto results = result_map | std::views::values | std::views::as_rvalue | std::ranges::to<std::vector>();
-  const auto freq_dict_order = query_.get_freq_dict_order();
-  auto middle_iter = std::ranges::next(results.begin(), max_results, results.end());
-  std::ranges::partial_sort(results, middle_iter, [&freq_dict_order](const auto& a, const auto& b) {
-    auto len_a = utf8::distance(a.matched.begin(), a.matched.end());
-    auto len_b = utf8::distance(b.matched.begin(), b.matched.end());
-    if (len_a != len_b) {
-      return len_a > len_b;
-    }
-
-    auto steps_a = a.preprocessor_steps;
-    auto steps_b = b.preprocessor_steps;
-    if (steps_a != steps_b) {
-      return steps_a < steps_b;
-    }
-
-    auto trace_len_a = a.trace.size();
-    auto trace_len_b = b.trace.size();
-    if (trace_len_a != trace_len_b) {
-      return trace_len_a < trace_len_b;
-    }
-
-    auto match_a = a.term.expression == a.deinflected;
-    auto match_b = b.term.expression == b.deinflected;
-    if (match_a != match_b) {
-      return match_a > match_b;
-    }
-
-    for (const auto& dict_name : freq_dict_order) {
-      const int freq_a = get_freq_value_for_dict(a.term, dict_name);
-      const int freq_b = get_freq_value_for_dict(b.term, dict_name);
-      if (freq_a != freq_b) {
-        return freq_a < freq_b;
+  std::optional<std::string_view> frequency_dictionary;
+  bool frequency_descending = false;
+  switch (options.frequency_order) {
+    case LookupFrequencyOrder::Auto:
+      // Preserves the previous behaviour: order by the first frequency
+      // dictionary that was added, in the direction its mode implies.
+      if (!query_.freq_dicts_.empty()) {
+        frequency_dictionary = query_.freq_dicts_.front().name;
+        frequency_descending = query_.primary_frequency_mode_ == DictionaryQuery::FrequencyMode::Occurrence;
       }
-    }
+      break;
+    case LookupFrequencyOrder::Ascending:
+    case LookupFrequencyOrder::Descending:
+      // An unknown name leaves frequency out of the comparison rather than
+      // silently falling back to a dictionary the caller did not ask for.
+      if (options.frequency_dictionary.has_value()) {
+        const auto selected =
+            std::ranges::find(query_.freq_dicts_, *options.frequency_dictionary, &DictionaryQuery::Dictionary::name);
+        if (selected != query_.freq_dicts_.end()) {
+          frequency_dictionary = selected->name;
+          frequency_descending = options.frequency_order == LookupFrequencyOrder::Descending;
+        }
+      }
+      break;
+    case LookupFrequencyOrder::Disabled:
+      break;
+  }
+  const std::optional<std::string_view> primary_reading =
+      options.primary_reading.has_value() && !options.primary_reading->empty() ? options.primary_reading : std::nullopt;
+  const size_t retained_count = std::min(results.size(), static_cast<size_t>(max_results));
+  auto middle_iter = std::ranges::next(results.begin(), static_cast<std::ptrdiff_t>(retained_count));
+  std::ranges::partial_sort(
+      results, middle_iter,
+      [primary_reading, frequency_dictionary, frequency_descending](const auto& a, const auto& b) {
+        if (primary_reading.has_value()) {
+          const std::string_view reading_a =
+              a.term.reading.empty() ? std::string_view(a.term.expression) : a.term.reading;
+          const std::string_view reading_b =
+              b.term.reading.empty() ? std::string_view(b.term.expression) : b.term.reading;
+          const bool primary_a = reading_a == *primary_reading;
+          const bool primary_b = reading_b == *primary_reading;
+          if (primary_a != primary_b) {
+            return primary_a;
+          }
+        }
 
-    if (a.term.score != b.term.score) {
-      return a.term.score > b.term.score;
-    }
+        auto len_a = utf8::distance(a.matched.begin(), a.matched.end());
+        auto len_b = utf8::distance(b.matched.begin(), b.matched.end());
+        if (len_a != len_b) {
+          return len_a > len_b;
+        }
 
-    auto a_reading_expr_match = a.term.expression == a.term.reading;
-    auto b_reading_expr_match = b.term.expression == b.term.reading;
-    return a_reading_expr_match > b_reading_expr_match;
-  });
+        auto steps_a = a.preprocessor_steps;
+        auto steps_b = b.preprocessor_steps;
+        if (steps_a != steps_b) {
+          return steps_a < steps_b;
+        }
 
-  if (results.size() > static_cast<size_t>(max_results)) {
-    results.resize(max_results);
+        auto trace_len_a = a.trace.size();
+        auto trace_len_b = b.trace.size();
+        if (trace_len_a != trace_len_b) {
+          return trace_len_a < trace_len_b;
+        }
+
+        auto match_a = a.term.expression == a.deinflected;
+        auto match_b = b.term.expression == b.deinflected;
+        if (match_a != match_b) {
+          return match_a > match_b;
+        }
+
+        if (frequency_dictionary.has_value()) {
+          const auto freq_a = get_freq_value_for_dict(a.term, *frequency_dictionary, frequency_descending);
+          const auto freq_b = get_freq_value_for_dict(b.term, *frequency_dictionary, frequency_descending);
+          if (freq_a.has_value() != freq_b.has_value()) {
+            return freq_a.has_value();
+          }
+          if (freq_a.has_value() && *freq_a != *freq_b) {
+            return frequency_descending ? *freq_a > *freq_b : *freq_a < *freq_b;
+          }
+        }
+
+        if (a.term.score != b.term.score) {
+          return a.term.score > b.term.score;
+        }
+
+        auto a_reading_expr_match = a.term.expression == a.term.reading;
+        auto b_reading_expr_match = b.term.expression == b.term.reading;
+        return a_reading_expr_match > b_reading_expr_match;
+      });
+
+  if (results.size() > retained_count) {
+    results.resize(retained_count);
   }
 
   for (auto& r : results) {

--- a/src/lookup.cpp
+++ b/src/lookup.cpp
@@ -21,17 +21,18 @@ std::vector<std::string> split_whitespace(const std::string& str) {
   return result;
 }
 
-std::optional<int> get_freq_value_for_dict(const TermResult& term, std::string_view dictionary_name, bool descending) {
-  std::optional<int> frequency;
+std::optional<double> get_freq_value_for_dict(const TermResult& term, std::string_view dictionary_name,
+                                              bool descending) {
+  std::optional<double> frequency;
   for (const auto& frequency_entry : term.frequencies) {
     if (frequency_entry.dict_name != dictionary_name || frequency_entry.frequencies.empty()) {
       continue;
     }
 
     for (const auto& candidate : frequency_entry.frequencies) {
-      frequency = frequency.has_value() ? std::optional<int>(descending ? std::max(*frequency, candidate.value)
-                                                                       : std::min(*frequency, candidate.value))
-                                        : std::optional<int>(candidate.value);
+      frequency = frequency.has_value() ? std::optional<double>(descending ? std::max(*frequency, candidate.value)
+                                                                          : std::min(*frequency, candidate.value))
+                                        : std::optional<double>(candidate.value);
     }
   }
 

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -5,11 +5,14 @@
 #include <zstd.h>
 
 #include <algorithm>
+#include <array>
+#include <cctype>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <memory>
 #include <ranges>
 #include <string_view>
@@ -115,6 +118,16 @@ void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
   dict.data->blobs = memory::map_rd(path + "/blobs.bin");
   if (!dict.data->blobs) {
     return;
+  }
+
+  if (type == FREQ && freq_dicts_.empty()) {
+    if (summary.frequencyMode == "occurrence-based") {
+      primary_frequency_mode_ = FrequencyMode::Occurrence;
+    } else if (summary.frequencyMode == "rank-based") {
+      primary_frequency_mode_ = FrequencyMode::Rank;
+    } else {
+      primary_frequency_mode_ = infer_frequency_mode(*dict.data, summary.sourceLanguage);
+    }
   }
 
   dict.data->media = memory::map_rd(path + "/media.bin");
@@ -256,52 +269,123 @@ std::vector<TermResult> DictionaryQuery::query_raw(const std::string& expression
 void DictionaryQuery::query_freq(std::vector<TermResult>& terms) const {
   for (auto& term : terms) {
     for (const auto& [name, styles, data] : freq_dicts_) {
-      uint64_t offset_addr = data->table(term.expression);
-      if (offset_addr == 0) {
-        continue;
-      }
-      const uint8_t* index_addr = data->blobs.data + offset_addr;
-      auto count = read_val<uint32_t>(index_addr);
-
-      std::vector<Frequency> frequencies;
-      for (uint32_t i = 0; i < count; i++) {
-        auto offset = read_val<uint64_t>(index_addr);
-        const uint8_t* blob_addr = data->blobs.data + offset;
-
-        auto type = read_val<uint8_t>(blob_addr);
-        if (type != 1) {
-          continue;
-        }
-
-        auto expr_len = read_val<uint16_t>(blob_addr);
-        std::string_view expr = read_str(blob_addr, expr_len);
-        if (expr != term.expression) {
-          continue;
-        }
-
-        auto mode_len = read_val<uint8_t>(blob_addr);
-        std::string_view mode = read_str(blob_addr, mode_len);
-        if (mode != "freq") {
-          continue;
-        }
-
-        auto freq_data_size = read_val<uint32_t>(blob_addr);
-        std::string_view freq_data = read_str(blob_addr, freq_data_size);
-
-        ParsedFrequency parsed;
-        if (yomitan_parser::parse_frequency(freq_data, parsed)) {
-          if (!parsed.reading.empty() && parsed.reading != term.reading) {
-            continue;
-          }
-          frequencies.emplace_back(
-              Frequency{.value = parsed.value, .display_value = std::string(parsed.display_value)});
-        }
-      }
+      auto frequencies = query_frequencies(*data, term.expression, term.reading);
       if (!frequencies.empty()) {
         term.frequencies.emplace_back(FrequencyEntry{.dict_name = name, .frequencies = std::move(frequencies)});
       }
     }
   }
+}
+
+std::vector<Frequency> DictionaryQuery::query_frequencies(const DictionaryData& data, const std::string& expression,
+                                                          std::optional<std::string_view> reading) {
+  uint64_t offset_addr = data.table(expression);
+  if (offset_addr == 0) {
+    return {};
+  }
+  const uint8_t* index_addr = data.blobs.data + offset_addr;
+  auto count = read_val<uint32_t>(index_addr);
+
+  std::vector<Frequency> frequencies;
+  for (uint32_t i = 0; i < count; i++) {
+    auto offset = read_val<uint64_t>(index_addr);
+    const uint8_t* blob_addr = data.blobs.data + offset;
+
+    auto type = read_val<uint8_t>(blob_addr);
+    if (type != 1) {
+      continue;
+    }
+
+    auto expr_len = read_val<uint16_t>(blob_addr);
+    std::string_view expr = read_str(blob_addr, expr_len);
+    if (expr != expression) {
+      continue;
+    }
+
+    auto mode_len = read_val<uint8_t>(blob_addr);
+    std::string_view mode = read_str(blob_addr, mode_len);
+    if (mode != "freq") {
+      continue;
+    }
+
+    auto freq_data_size = read_val<uint32_t>(blob_addr);
+    std::string_view freq_data = read_str(blob_addr, freq_data_size);
+
+    ParsedFrequency parsed;
+    if (!yomitan_parser::parse_frequency(freq_data, parsed)) {
+      continue;
+    }
+    if (reading.has_value() && !parsed.reading.empty() && parsed.reading != *reading) {
+      continue;
+    }
+
+    Frequency frequency{.value = parsed.value, .display_value = std::move(parsed.display_value)};
+    const bool duplicate = std::ranges::any_of(frequencies, [&](const Frequency& existing) {
+      return existing.value == frequency.value && existing.display_value == frequency.display_value;
+    });
+    if (!duplicate) {
+      frequencies.push_back(std::move(frequency));
+    }
+  }
+  return frequencies;
+}
+
+DictionaryQuery::FrequencyMode DictionaryQuery::infer_frequency_mode(
+    const DictionaryData& data, const std::optional<std::string>& source_language) {
+  if (source_language.has_value() && !source_language->empty()) {
+    std::string normalized_language = *source_language;
+    std::ranges::transform(normalized_language, normalized_language.begin(),
+                           [](unsigned char character) { return static_cast<char>(std::tolower(character)); });
+    if (normalized_language != "ja") {
+      return FrequencyMode::Rank;
+    }
+  }
+
+  static constexpr std::array<std::string_view, 10> more_common_terms = {
+      "来る", "言う", "出る", "入る", "方", "男", "女", "今", "何", "時",
+  };
+  static constexpr std::array<std::string_view, 10> less_common_terms = {
+      "行なう", "論じる", "過す", "行方", "人口", "猫", "犬", "滝", "理", "暁",
+  };
+
+  struct Details {
+    bool has_value = false;
+    int min_value = std::numeric_limits<int>::max();
+    int max_value = std::numeric_limits<int>::min();
+  };
+
+  auto get_details = [&](std::string_view term) {
+    Details details;
+    for (const auto& frequency : query_frequencies(data, std::string(term), std::nullopt)) {
+      details.has_value = true;
+      details.min_value = std::min(details.min_value, frequency.value);
+      details.max_value = std::max(details.max_value, frequency.value);
+    }
+    return details;
+  };
+
+  std::array<Details, more_common_terms.size()> common_details;
+  std::array<Details, less_common_terms.size()> rare_details;
+  std::ranges::transform(more_common_terms, common_details.begin(), get_details);
+  std::ranges::transform(less_common_terms, rare_details.begin(), get_details);
+
+  int result = 0;
+  // Widened so the differences below cannot overflow at the int extremes.
+  auto sign = [](long long value) { return (value > 0) - (value < 0); };
+  for (const auto& common : common_details) {
+    if (!common.has_value) {
+      continue;
+    }
+    for (const auto& rare : rare_details) {
+      if (!rare.has_value) {
+        continue;
+      }
+      result += sign(static_cast<long long>(common.max_value) - rare.min_value) +
+                sign(static_cast<long long>(common.min_value) - rare.max_value);
+    }
+  }
+
+  return result > 0 ? FrequencyMode::Occurrence : FrequencyMode::Rank;
 }
 
 void DictionaryQuery::query_pitch(std::vector<TermResult>& terms) const {

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -315,7 +315,7 @@ std::vector<Frequency> DictionaryQuery::query_frequencies(const DictionaryData& 
     if (!yomitan_parser::parse_frequency(freq_data, parsed)) {
       continue;
     }
-    if (reading.has_value() && !parsed.reading.empty() && parsed.reading != *reading) {
+    if (reading.has_value() && parsed.reading.has_value() && *parsed.reading != *reading) {
       continue;
     }
 
@@ -350,8 +350,8 @@ DictionaryQuery::FrequencyMode DictionaryQuery::infer_frequency_mode(
 
   struct Details {
     bool has_value = false;
-    int min_value = std::numeric_limits<int>::max();
-    int max_value = std::numeric_limits<int>::min();
+    double min_value = std::numeric_limits<double>::max();
+    double max_value = std::numeric_limits<double>::lowest();
   };
 
   auto get_details = [&](std::string_view term) {
@@ -370,8 +370,7 @@ DictionaryQuery::FrequencyMode DictionaryQuery::infer_frequency_mode(
   std::ranges::transform(less_common_terms, rare_details.begin(), get_details);
 
   int result = 0;
-  // Widened so the differences below cannot overflow at the int extremes.
-  auto sign = [](long long value) { return (value > 0) - (value < 0); };
+  auto sign = [](double value) { return (value > 0) - (value < 0); };
   for (const auto& common : common_details) {
     if (!common.has_value) {
       continue;
@@ -380,8 +379,7 @@ DictionaryQuery::FrequencyMode DictionaryQuery::infer_frequency_mode(
       if (!rare.has_value) {
         continue;
       }
-      result += sign(static_cast<long long>(common.max_value) - rare.min_value) +
-                sign(static_cast<long long>(common.min_value) - rare.max_value);
+      result += sign(common.max_value - rare.min_value) + sign(common.min_value - rare.max_value);
     }
   }
 


### PR DESCRIPTION
**Draft, because the last hunk is an ABI break and that is a call for you, not me.** Everything below is working and verified; I am opening it so the shape of the change is visible rather than described.

Stacked on #26 — the diff will shrink to six files once that lands. Read this one commit only: `2830548`.

## The bug

`Frequency::value` is an `int` and `display_value` a `std::string` backfilled with `std::to_string(value)`. And `parse_frequency` has no branch for a frequency given as a JSON string, which the format permits and which dictionaries use to carry a marker next to the number. Those entries fail every parse branch and are dropped.

A three-entry `term_meta_bank`, queried through `hoshidicts-cli freq`:

| entry | `main` | this PR |
|---|---|---|
| `{"value":2.5,"displayValue":"2.5"}` | **dropped** (`count: 0`) | `val: 2.5  display_val: 2.5` |
| `"rank 7.25"` | **dropped** (`count: 0`) | `val: 7.25  display_val: rank 7.25` |
| `12` | `val: 12  display_val: 12` | `val: 12  display_val: <null>` |

Two of three shapes are silently discarded today. The third shows the other half: `main` cannot tell an archive that supplied no display value from one that supplied `"12"`.

## The change

- `Frequency::value` → `double`; `display_value` → `std::optional<std::string>`. Non-finite values rejected rather than stored.
- String frequencies parsed with the same regex Yomitan uses in `Translator._numberRegex`, keeping the original text as the display value.

## The part that needs your decision

`hd_frequency` changes **in place**:

```c
 typedef struct hd_frequency {
-  int32_t value;
+  double value;
   hd_str display_value;
+  int display_value_is_null;
 } hd_frequency;
```

That breaks the C ABI. The alternative is a versioned `hd_frequency_v2` and a parallel `hd_term_result_v2` / `hd_lookup_result_v2` family, which is what I originally did downstream — and it was a mistake. It cost ~170 lines of duplicated marshalling in `hoshidicts_c.cpp` and I have since deleted it, because:

- the C bindings landed in #17 on 2026-08-05, so there has been very little time for consumers to appear;
- the only two I know of are GameSentenceMiner, which is mine and which I will update, and [chimahon](https://github.com/sohilsayed/chimahon), which uses the C++ API through JNI and never touches `hd_*`.

Changing it in place is cheap now and expensive later, which is the whole reason I am raising it now rather than sitting on the fork.

**`struct Frequency` is also public** (`include/hoshidicts/query.hpp`), so this is a source break for C++ consumers too. Concretely, chimahon does `new_string(env, frequency.display_value)`, which will not compile against `std::optional<std::string>`. `static_cast<jint>(frequency.value)` survives. So chimahon needs a one-line change either way; I mention it so the cost is on the table rather than discovered later.

If you would rather not break either surface, say so and I will close this — GSM does not need it. Every frequency dictionary I measured is integer-only:

| dictionary | entries | non-integer values |
|---|---|---|
| BCCWJ | 1,000,219 | 0 |
| JPDB v2.2 Kana | 338,814 | 0 |
| Jiten | 587,544 | 0 |
| JPDB v2.2 | 278,946 | 0 |

So this is worth doing for correctness on dictionaries that do use the other shapes, not because anything popular is currently broken.

## Verification

GCC 14.4, Release, `-DHOSHIDICTS_CLI=ON`: builds clean, 0 errors, 0 warnings. The table above is from two CLI binaries built from clean checkouts of #26's branch and this one.

Needs `-include cstdint` until #21 lands.