### PR TITLE
feat: match Yomitan redirect lookup semantics

### DIFF
--- a/include/hoshidicts/lookup.hpp
+++ b/include/hoshidicts/lookup.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "deinflector.hpp"
@@ -14,11 +16,21 @@ struct LookupResult {
   int preprocessor_steps;
 };
 
+enum class LookupFrequencyOrder { Auto, Ascending, Descending, Disabled };
+
+struct LookupOptions {
+  std::optional<std::string_view> primary_reading;
+  std::optional<std::string_view> frequency_dictionary;
+  LookupFrequencyOrder frequency_order = LookupFrequencyOrder::Auto;
+};
+
 class Lookup {
  public:
   Lookup(DictionaryQuery& query, Deinflector& deinflector) : query_(query), deinflector_(deinflector) {};
   std::vector<LookupResult> lookup(const std::string& lookup_string, int max_results = 16,
                                    size_t scan_length = 16) const;
+  std::vector<LookupResult> lookup(const std::string& lookup_string, int max_results, size_t scan_length,
+                                   const LookupOptions& options) const;
 
  private:
   static void filter_by_pos(std::vector<TermResult>& terms, const DeinflectionResult& d);

--- a/include/hoshidicts/query.hpp
+++ b/include/hoshidicts/query.hpp
@@ -28,6 +28,11 @@ struct MediaFileView {
   size_t size;
 };
 
+struct DictionaryRedirect {
+  std::string form_of;
+  std::vector<std::string> inflection_rules;
+};
+
 struct GlossaryEntry {
   std::string dict_name;
   std::string glossary;
@@ -35,6 +40,9 @@ struct GlossaryEntry {
   std::string term_tags;
   const uint8_t* compressed_data = nullptr;
   uint32_t compressed_size = 0;
+  std::vector<DictionaryRedirect> redirects;
+  bool materialized = false;
+  bool has_display_definitions = true;
 };
 
 struct FrequencyEntry {
@@ -111,6 +119,7 @@ class DictionaryQuery {
   friend class Lookup;
   std::vector<TermResult> query_raw(const std::string& expression) const;
   void materialize(TermResult& term) const;
+  static void prune_empty_glossaries(TermResult& term);
 
   struct DictionaryData;
   enum class FrequencyMode { Rank, Occurrence };

--- a/include/hoshidicts/query.hpp
+++ b/include/hoshidicts/query.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <unordered_map>
 
 #if defined(__clang__) && defined(__APPLE__)
 #define SWIFT_IMPORT_UNSAFE __attribute__((swift_attr("import_unsafe")))
@@ -112,6 +113,7 @@ class DictionaryQuery {
   void materialize(TermResult& term) const;
 
   struct DictionaryData;
+  enum class FrequencyMode { Rank, Occurrence };
   struct Dictionary {
     Dictionary();
     ~Dictionary();
@@ -129,8 +131,13 @@ class DictionaryQuery {
   enum DictionaryType : uint8_t { TERM, FREQ, PITCH, KANJI };
 
   void add_dict(const std::string& path, DictionaryType);
+  static std::vector<Frequency> query_frequencies(const DictionaryData& data, const std::string& expression,
+                                                  std::optional<std::string_view> reading);
+  static FrequencyMode infer_frequency_mode(const DictionaryData& data,
+                                            const std::optional<std::string>& source_language);
 
   static std::string decompress_glossary(const void* data, size_t size);
+  FrequencyMode primary_frequency_mode_ = FrequencyMode::Rank;
   std::vector<Dictionary> term_dicts_;
   std::vector<Dictionary> freq_dicts_;
   std::vector<Dictionary> pitch_dicts_;

--- a/include/hoshidicts_c.h
+++ b/include/hoshidicts_c.h
@@ -155,11 +155,31 @@ typedef struct hd_lookup_result {
   int32_t preprocessor_steps;
 } hd_lookup_result;
 
+typedef enum hd_lookup_frequency_order {
+  HD_LOOKUP_FREQUENCY_ORDER_AUTO = 0,
+  HD_LOOKUP_FREQUENCY_ORDER_ASCENDING = 1,
+  HD_LOOKUP_FREQUENCY_ORDER_DESCENDING = 2,
+  HD_LOOKUP_FREQUENCY_ORDER_DISABLED = 3,
+} hd_lookup_frequency_order;
+
+// A null hd_str leaves the corresponding preference unset.
+typedef struct hd_lookup_options {
+  hd_str primary_reading;
+  hd_str frequency_dictionary;
+  int32_t frequency_order;
+} hd_lookup_options;
+
 hd_lookup* hd_lookup_new(hd_query* q, hd_deinflector* d);
 void hd_lookup_free(hd_lookup* l);
 
 hd_lookup_results* hd_lookup_run(const hd_lookup* l, const char* lookup_string, int max_results, size_t scan_length,
                                  const hd_lookup_result** out_results, size_t* out_count);
+// As hd_lookup_run, but applies the caller's sort preferences before the
+// max_results cap, so the cap keeps the results the caller would have ranked
+// highest. Passing a null options pointer is equivalent to hd_lookup_run.
+hd_lookup_results* hd_lookup_run_with_options(const hd_lookup* l, const char* lookup_string, int max_results,
+                                              size_t scan_length, const hd_lookup_options* options,
+                                              const hd_lookup_result** out_results, size_t* out_count);
 void hd_lookup_results_free(hd_lookup_results* r);
 
 #ifdef __cplusplus

--- a/src/hoshidicts_c.cpp
+++ b/src/hoshidicts_c.cpp
@@ -2,6 +2,9 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string_view>
 
 #include "hoshidicts/deinflector.hpp"
 #include "hoshidicts/importer.hpp"
@@ -365,66 +368,126 @@ hd_lookup* hd_lookup_new(hd_query* q, hd_deinflector* d) {
 
 void hd_lookup_free(hd_lookup* l) { delete l; }
 
+static void marshal_lookup_results(hd_lookup_results* r) {
+  size_t trace_count = 0;
+  size_t glossaries_count = 0;
+  size_t freq_entry_count = 0;
+  size_t freq_count = 0;
+  size_t pitch_entry_count = 0;
+  size_t pitch_count = 0;
+  size_t transcription_count = 0;
+  for (const auto& lookup_result : r->res) {
+    trace_count += lookup_result.trace.size();
+    glossaries_count += lookup_result.term.glossaries.size();
+    freq_entry_count += lookup_result.term.frequencies.size();
+    pitch_entry_count += lookup_result.term.pitches.size();
+    for (const auto& freq_entry : lookup_result.term.frequencies) {
+      freq_count += freq_entry.frequencies.size();
+    }
+    for (const auto& pitch_entry : lookup_result.term.pitches) {
+      pitch_count += pitch_entry.pitches.size();
+      transcription_count += pitch_entry.transcriptions.size();
+    }
+  }
+  r->trace.reserve(trace_count);
+  r->glossary_entries.reserve(glossaries_count);
+  r->frequency_entries.reserve(freq_entry_count);
+  r->frequencies.reserve(freq_count);
+  r->pitch_entries.reserve(pitch_entry_count);
+  r->pitches.reserve(pitch_count);
+  r->transcriptions.reserve(transcription_count);
+
+  for (const auto& lookup_result : r->res) {
+    const auto& term_result = lookup_result.term;
+    hd_lookup_result lr;
+    lr.matched = hd_str{lookup_result.matched.c_str(), lookup_result.matched.size()};
+    lr.deinflected = hd_str{lookup_result.deinflected.c_str(), lookup_result.deinflected.size()};
+    lr.preprocessor_steps = lookup_result.preprocessor_steps;
+
+    size_t trace_start = r->trace.size();
+    for (const auto& group : lookup_result.trace) {
+      r->trace.push_back(hd_transform_group{hd_str{group.name.c_str(), group.name.size()},
+                                            hd_str{group.description.c_str(), group.description.size()}});
+    }
+    lr.trace = r->trace.data() + trace_start;
+    lr.trace_count = lookup_result.trace.size();
+
+    lr.term.expression = hd_str{term_result.expression.c_str(), term_result.expression.size()};
+    lr.term.reading = hd_str{term_result.reading.c_str(), term_result.reading.size()};
+    lr.term.rules = hd_str{term_result.rules.c_str(), term_result.rules.size()};
+    lr.term.score = term_result.score;
+
+    build_glossaries(r->glossary_entries, term_result, lr.term);
+    build_frequencies(r->frequency_entries, r->frequencies, term_result, lr.term);
+    build_pitches(r->pitch_entries, r->pitches, r->transcriptions, term_result, lr.term);
+
+    r->results.push_back(lr);
+  }
+}
+
 hd_lookup_results* hd_lookup_run(const hd_lookup* l, const char* lookup_string, int max_results, size_t scan_length,
                                  const hd_lookup_result** out_results, size_t* out_count) {
   try {
     auto r = std::make_unique<hd_lookup_results>();
     r->res = l->lookup.lookup(lookup_string, max_results, scan_length);
+    marshal_lookup_results(r.get());
 
-    size_t trace_count = 0;
-    size_t glossaries_count = 0;
-    size_t freq_entry_count = 0;
-    size_t freq_count = 0;
-    size_t pitch_entry_count = 0;
-    size_t pitch_count = 0;
-    size_t transcription_count = 0;
-    for (const auto& lookup_result : r->res) {
-      trace_count += lookup_result.trace.size();
-      glossaries_count += lookup_result.term.glossaries.size();
-      freq_entry_count += lookup_result.term.frequencies.size();
-      pitch_entry_count += lookup_result.term.pitches.size();
-      for (const auto& freq_entry : lookup_result.term.frequencies) {
-        freq_count += freq_entry.frequencies.size();
-      }
-      for (const auto& pitch_entry : lookup_result.term.pitches) {
-        pitch_count += pitch_entry.pitches.size();
-        transcription_count += pitch_entry.transcriptions.size();
+    *out_results = r->results.data();
+    *out_count = r->results.size();
+    return r.release();
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+// An empty hd_str means "unset"; a non-empty one with a null pointer is a
+// caller error rather than an empty preference.
+static std::optional<std::string_view> optional_string_view(hd_str value) {
+  if (value.len == 0) {
+    return std::nullopt;
+  }
+  if (value.ptr == nullptr) {
+    throw std::invalid_argument("non-empty lookup option has a null pointer");
+  }
+  return std::string_view(value.ptr, value.len);
+}
+
+hd_lookup_results* hd_lookup_run_with_options(const hd_lookup* l, const char* lookup_string, int max_results,
+                                              size_t scan_length, const hd_lookup_options* options,
+                                              const hd_lookup_result** out_results, size_t* out_count) {
+  if (l == nullptr || lookup_string == nullptr || out_results == nullptr || out_count == nullptr || max_results <= 0 ||
+      scan_length == 0) {
+    return nullptr;
+  }
+  *out_results = nullptr;
+  *out_count = 0;
+
+  try {
+    LookupOptions native_options;
+    if (options != nullptr) {
+      native_options.primary_reading = optional_string_view(options->primary_reading);
+      native_options.frequency_dictionary = optional_string_view(options->frequency_dictionary);
+      switch (options->frequency_order) {
+        case HD_LOOKUP_FREQUENCY_ORDER_AUTO:
+          native_options.frequency_order = LookupFrequencyOrder::Auto;
+          break;
+        case HD_LOOKUP_FREQUENCY_ORDER_ASCENDING:
+          native_options.frequency_order = LookupFrequencyOrder::Ascending;
+          break;
+        case HD_LOOKUP_FREQUENCY_ORDER_DESCENDING:
+          native_options.frequency_order = LookupFrequencyOrder::Descending;
+          break;
+        case HD_LOOKUP_FREQUENCY_ORDER_DISABLED:
+          native_options.frequency_order = LookupFrequencyOrder::Disabled;
+          break;
+        default:
+          return nullptr;
       }
     }
-    r->trace.reserve(trace_count);
-    r->glossary_entries.reserve(glossaries_count);
-    r->frequency_entries.reserve(freq_entry_count);
-    r->frequencies.reserve(freq_count);
-    r->pitch_entries.reserve(pitch_entry_count);
-    r->pitches.reserve(pitch_count);
-    r->transcriptions.reserve(transcription_count);
 
-    for (const auto& lookup_result : r->res) {
-      const auto& term_result = lookup_result.term;
-      hd_lookup_result lr;
-      lr.matched = hd_str{lookup_result.matched.c_str(), lookup_result.matched.size()};
-      lr.deinflected = hd_str{lookup_result.deinflected.c_str(), lookup_result.deinflected.size()};
-      lr.preprocessor_steps = lookup_result.preprocessor_steps;
-
-      size_t trace_start = r->trace.size();
-      for (const auto& group : lookup_result.trace) {
-        r->trace.push_back(hd_transform_group{hd_str{group.name.c_str(), group.name.size()},
-                                              hd_str{group.description.c_str(), group.description.size()}});
-      }
-      lr.trace = r->trace.data() + trace_start;
-      lr.trace_count = lookup_result.trace.size();
-
-      lr.term.expression = hd_str{term_result.expression.c_str(), term_result.expression.size()};
-      lr.term.reading = hd_str{term_result.reading.c_str(), term_result.reading.size()};
-      lr.term.rules = hd_str{term_result.rules.c_str(), term_result.rules.size()};
-      lr.term.score = term_result.score;
-
-      build_glossaries(r->glossary_entries, term_result, lr.term);
-      build_frequencies(r->frequency_entries, r->frequencies, term_result, lr.term);
-      build_pitches(r->pitch_entries, r->pitches, r->transcriptions, term_result, lr.term);
-
-      r->results.push_back(lr);
-    }
+    auto r = std::make_unique<hd_lookup_results>();
+    r->res = l->lookup.lookup(lookup_string, max_results, scan_length, native_options);
+    marshal_lookup_results(r.get());
 
     *out_results = r->results.data();
     *out_count = r->results.size();

--- a/src/importer.cpp
+++ b/src/importer.cpp
@@ -184,22 +184,25 @@ ProcessedFile process_term_bank(const std::string& content) {
   }
 
   std::vector<char> compressed;
-  ZSTD_CCtx* cctx = ZSTD_createCCtx();
+  std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> cctx(ZSTD_createCCtx(), ZSTD_freeCCtx);
   if (!cctx) {
     return processed;
   }
 
   for (auto& term : out) {
-    const std::string_view glossary = term.glossary.str;
+    ParsedGlossary parsed_glossary;
+    if (!yomitan_parser::parse_glossary(term.glossary.str, parsed_glossary)) {
+      throw std::runtime_error("failed to parse term glossary");
+    }
+    const std::string_view glossary = parsed_glossary.display_json;
     uint64_t glossary_hash = XXH3_64bits(glossary.data(), glossary.size());
     auto it = processed.glossaries.find(glossary_hash);
     if (it == processed.glossaries.end()) {
       const size_t bound = ZSTD_compressBound(glossary.size());
       compressed.resize(bound);
       const size_t compressed_size =
-          ZSTD_compressCCtx(cctx, compressed.data(), bound, glossary.data(), glossary.size(), 0);
+          ZSTD_compressCCtx(cctx.get(), compressed.data(), bound, glossary.data(), glossary.size(), 0);
       if (ZSTD_isError(compressed_size)) {
-        ZSTD_freeCCtx(cctx);
         throw std::runtime_error("failed to compress glossary");
       }
       compressed.resize(compressed_size);
@@ -229,8 +232,18 @@ ProcessedFile process_term_bank(const std::string& content) {
     write_str(processed.data, term.rules);
     write_val<uint8_t>(processed.data, term.term_tags.size());
     write_str(processed.data, term.term_tags);
-    write_val<uint32_t>(processed.data, 0);
+    write_val<uint32_t>(processed.data, static_cast<uint32_t>(parsed_glossary.redirects.size()));
+    for (const auto& redirect : parsed_glossary.redirects) {
+      write_val<uint32_t>(processed.data, static_cast<uint32_t>(redirect.form_of.size()));
+      write_str(processed.data, redirect.form_of);
+      write_val<uint32_t>(processed.data, static_cast<uint32_t>(redirect.inflection_rules.size()));
+      for (const auto& rule : redirect.inflection_rules) {
+        write_val<uint32_t>(processed.data, static_cast<uint32_t>(rule.size()));
+        write_str(processed.data, rule);
+      }
+    }
     write_val<int32_t>(processed.data, static_cast<int32_t>(term.score));
+    write_val<uint8_t>(processed.data, parsed_glossary.has_display_definitions ? 1 : 0);
 
     processed.offsets.emplace_back(XXH3_64bits(expr.data(), expr.size()), offset);
     if (reading != expr) {
@@ -238,7 +251,6 @@ ProcessedFile process_term_bank(const std::string& content) {
     }
     processed.count++;
   }
-  ZSTD_freeCCtx(cctx);
 
   return processed;
 }
@@ -687,7 +699,7 @@ ImportResult dictionary_importer::import(const std::string& zip_path, const std:
       throw std::runtime_error("failed to write index.json");
     }
 
-    std::ofstream sui(path + "/.hoshidicts_3", std::ios::binary);
+    std::ofstream sui(path + "/.hoshidicts_4", std::ios::binary);
     result.success = true;
   } catch (const std::exception& e) {
     result.success = false;

--- a/src/json/yomitan_parser.cpp
+++ b/src/json/yomitan_parser.cpp
@@ -1,6 +1,7 @@
 #include "yomitan_parser.hpp"
 
 #include <string_view>
+#include <tuple>
 #include <variant>
 
 template <>
@@ -132,6 +133,43 @@ bool yomitan_parser::parse_index(std::string_view content, Index& out) {
 bool yomitan_parser::parse_term_bank(std::string_view content, std::vector<Term>& out) {
   auto error = glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = false}>(out, content);
   return !error;
+}
+
+bool yomitan_parser::parse_glossary(std::string_view content, ParsedGlossary& out) {
+  std::vector<glz::raw_json> definitions;
+  if (glz::read_json(definitions, content)) {
+    return false;
+  }
+
+  ParsedGlossary result;
+  result.display_json.push_back('[');
+  for (const auto& definition : definitions) {
+    const size_t first_token = definition.str.find_first_not_of(" \t\r\n");
+    if (first_token == std::string::npos || definition.str[first_token] != '[') {
+      if (result.has_display_definitions) {
+        result.display_json.push_back(',');
+      }
+      result.display_json.append(definition.str);
+      result.has_display_definitions = true;
+      continue;
+    }
+
+    // Yomitan treats every top-level array as dictionary deinflection metadata
+    // and never displays it as a definition. Only schema-valid tuples are
+    // followed; malformed arrays are safely stripped.
+    std::tuple<std::string, std::vector<std::string>> tuple;
+    if (glz::read_json(tuple, definition.str)) {
+      continue;
+    }
+    auto& [form_of, inflection_rules] = tuple;
+    if (!form_of.empty()) {
+      result.redirects.push_back(
+          TermRedirect{.form_of = std::move(form_of), .inflection_rules = std::move(inflection_rules)});
+    }
+  }
+  result.display_json.push_back(']');
+  out = std::move(result);
+  return true;
 }
 
 bool yomitan_parser::parse_meta_bank(std::string_view content, std::vector<Meta>& out) {

--- a/src/json/yomitan_parser.hpp
+++ b/src/json/yomitan_parser.hpp
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <glaze/glaze.hpp>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -33,6 +34,17 @@ struct Term {
   glz::raw_json_view glossary;
   int64_t sequence = 0;
   std::string_view term_tags;
+};
+
+struct TermRedirect {
+  std::string form_of;
+  std::vector<std::string> inflection_rules;
+};
+
+struct ParsedGlossary {
+  std::string display_json;
+  std::vector<TermRedirect> redirects;
+  bool has_display_definitions = false;
 };
 
 struct Meta {
@@ -80,6 +92,7 @@ struct ParsedPitch {
 namespace yomitan_parser {
 bool parse_index(std::string_view content, Index& out);
 bool parse_term_bank(std::string_view content, std::vector<Term>& out);
+bool parse_glossary(std::string_view content, ParsedGlossary& out);
 bool parse_meta_bank(std::string_view content, std::vector<Meta>& out);
 bool parse_kanji_bank(std::string_view content, std::vector<Kanji>& out);
 bool parse_tag_bank(std::string_view content, std::vector<Tag>& out);

--- a/src/lookup.cpp
+++ b/src/lookup.cpp
@@ -45,7 +45,39 @@ std::vector<LookupResult> Lookup::lookup(const std::string& lookup_string, int m
 
 std::vector<LookupResult> Lookup::lookup(const std::string& lookup_string, int max_results, size_t scan_length,
                                          const LookupOptions& options) const {
+  if (max_results <= 0 || scan_length == 0) {
+    return {};
+  }
   std::map<std::pair<std::string, std::string>, LookupResult> result_map;
+
+  auto add_result = [&](TermResult term, const std::string& matched, const std::string& deinflected,
+                        std::vector<TransformGroup> trace, int preprocessor_steps) {
+    DictionaryQuery::prune_empty_glossaries(term);
+    if (term.glossaries.empty()) {
+      return;
+    }
+
+    auto key = std::make_pair(term.expression, term.reading);
+    auto it = result_map.find(key);
+    if (it != result_map.end()) {
+      // Keep the result associated with the longest source match.
+      if (utf8::distance(matched.begin(), matched.end()) <=
+          utf8::distance(it->second.matched.begin(), it->second.matched.end())) {
+        return;
+      }
+      it->second = LookupResult{.matched = matched,
+                                .deinflected = deinflected,
+                                .trace = std::move(trace),
+                                .term = std::move(term),
+                                .preprocessor_steps = preprocessor_steps};
+      return;
+    }
+    result_map.emplace(std::move(key), LookupResult{.matched = matched,
+                                                    .deinflected = deinflected,
+                                                    .trace = std::move(trace),
+                                                    .term = std::move(term),
+                                                    .preprocessor_steps = preprocessor_steps});
+  };
 
   size_t text_len = utf8::distance(lookup_string.begin(), lookup_string.end());
   size_t start = std::min(scan_length, text_len);
@@ -62,25 +94,33 @@ std::vector<LookupResult> Lookup::lookup(const std::string& lookup_string, int m
         filter_by_pos(terms, deinflection);
 
         for (auto& term : terms) {
-          // deduplicate glossaries
-          auto key = std::make_pair(term.expression, term.reading);
-          auto it = result_map.find(key);
-          if (it != result_map.end()) {
-            // we only need the longest matched form
-            if (utf8::distance(search_str.begin(), search_str.end()) >
-                utf8::distance(it->second.matched.begin(), it->second.matched.end())) {
-              it->second = LookupResult{.matched = search_str,
-                                        .deinflected = deinflection.text,
-                                        .trace = deinflection.trace,
-                                        .term = std::move(term),
-                                        .preprocessor_steps = variant.steps};
+          std::vector<DictionaryRedirect> redirects;
+          for (const auto& glossary : term.glossaries) {
+            for (const auto& redirect : glossary.redirects) {
+              const bool duplicate = std::ranges::any_of(redirects, [&](const DictionaryRedirect& existing) {
+                return existing.form_of == redirect.form_of && existing.inflection_rules == redirect.inflection_rules;
+              });
+              if (!duplicate) {
+                redirects.push_back(redirect);
+              }
             }
-          } else {
-            result_map.emplace(key, LookupResult{.matched = search_str,
-                                                 .deinflected = deinflection.text,
-                                                 .trace = deinflection.trace,
-                                                 .term = std::move(term),
-                                                 .preprocessor_steps = variant.steps});
+          }
+
+          add_result(std::move(term), search_str, deinflection.text, deinflection.trace, variant.steps);
+
+          // Match Yomitan's dictionary deinflection pass exactly: follow each
+          // source redirect once, query all enabled term dictionaries, do not
+          // apply the source POS condition to targets, and never recurse into
+          // redirects carried by those target entries.
+          for (const auto& redirect : redirects) {
+            auto target_terms = query_.query_raw(redirect.form_of);
+            auto redirect_trace = deinflection.trace;
+            for (const auto& rule : redirect.inflection_rules) {
+              redirect_trace.push_back(TransformGroup{.name = rule, .description = ""});
+            }
+            for (auto& target_term : target_terms) {
+              add_result(std::move(target_term), search_str, redirect.form_of, redirect_trace, variant.steps);
+            }
           }
         }
       }

--- a/src/lookup.cpp
+++ b/src/lookup.cpp
@@ -3,8 +3,8 @@
 #include <utf8.h>
 
 #include <algorithm>
-#include <climits>
 #include <map>
+#include <optional>
 #include <ranges>
 #include <sstream>
 
@@ -21,26 +21,30 @@ std::vector<std::string> split_whitespace(const std::string& str) {
   return result;
 }
 
-int get_freq_value_for_dict(const TermResult& term, const std::string& dict_name) {
+std::optional<int> get_freq_value_for_dict(const TermResult& term, std::string_view dictionary_name, bool descending) {
+  std::optional<int> frequency;
   for (const auto& frequency_entry : term.frequencies) {
-    if (frequency_entry.dict_name != dict_name) {
+    if (frequency_entry.dict_name != dictionary_name || frequency_entry.frequencies.empty()) {
       continue;
     }
 
-    int min_frequency = INT_MAX;
-    for (const auto& frequency : frequency_entry.frequencies) {
-      if (frequency.value >= 0) {
-        min_frequency = std::min(min_frequency, frequency.value);
-      }
+    for (const auto& candidate : frequency_entry.frequencies) {
+      frequency = frequency.has_value() ? std::optional<int>(descending ? std::max(*frequency, candidate.value)
+                                                                       : std::min(*frequency, candidate.value))
+                                        : std::optional<int>(candidate.value);
     }
-    return min_frequency;
   }
 
-  return INT_MAX;
+  return frequency;
 }
 }
 
 std::vector<LookupResult> Lookup::lookup(const std::string& lookup_string, int max_results, size_t scan_length) const {
+  return lookup(lookup_string, max_results, scan_length, LookupOptions{});
+}
+
+std::vector<LookupResult> Lookup::lookup(const std::string& lookup_string, int max_results, size_t scan_length,
+                                         const LookupOptions& options) const {
   std::map<std::pair<std::string, std::string>, LookupResult> result_map;
 
   size_t text_len = utf8::distance(lookup_string.begin(), lookup_string.end());
@@ -87,52 +91,98 @@ std::vector<LookupResult> Lookup::lookup(const std::string& lookup_string, int m
   }
 
   auto results = result_map | std::views::values | std::views::as_rvalue | std::ranges::to<std::vector>();
-  const auto freq_dict_order = query_.get_freq_dict_order();
-  auto middle_iter = std::ranges::next(results.begin(), max_results, results.end());
-  std::ranges::partial_sort(results, middle_iter, [&freq_dict_order](const auto& a, const auto& b) {
-    auto len_a = utf8::distance(a.matched.begin(), a.matched.end());
-    auto len_b = utf8::distance(b.matched.begin(), b.matched.end());
-    if (len_a != len_b) {
-      return len_a > len_b;
-    }
-
-    auto steps_a = a.preprocessor_steps;
-    auto steps_b = b.preprocessor_steps;
-    if (steps_a != steps_b) {
-      return steps_a < steps_b;
-    }
-
-    auto trace_len_a = a.trace.size();
-    auto trace_len_b = b.trace.size();
-    if (trace_len_a != trace_len_b) {
-      return trace_len_a < trace_len_b;
-    }
-
-    auto match_a = a.term.expression == a.deinflected;
-    auto match_b = b.term.expression == b.deinflected;
-    if (match_a != match_b) {
-      return match_a > match_b;
-    }
-
-    for (const auto& dict_name : freq_dict_order) {
-      const int freq_a = get_freq_value_for_dict(a.term, dict_name);
-      const int freq_b = get_freq_value_for_dict(b.term, dict_name);
-      if (freq_a != freq_b) {
-        return freq_a < freq_b;
+  std::optional<std::string_view> frequency_dictionary;
+  bool frequency_descending = false;
+  switch (options.frequency_order) {
+    case LookupFrequencyOrder::Auto:
+      // Preserves the previous behaviour: order by the first frequency
+      // dictionary that was added, in the direction its mode implies.
+      if (!query_.freq_dicts_.empty()) {
+        frequency_dictionary = query_.freq_dicts_.front().name;
+        frequency_descending = query_.primary_frequency_mode_ == DictionaryQuery::FrequencyMode::Occurrence;
       }
-    }
+      break;
+    case LookupFrequencyOrder::Ascending:
+    case LookupFrequencyOrder::Descending:
+      // An unknown name leaves frequency out of the comparison rather than
+      // silently falling back to a dictionary the caller did not ask for.
+      if (options.frequency_dictionary.has_value()) {
+        const auto selected =
+            std::ranges::find(query_.freq_dicts_, *options.frequency_dictionary, &DictionaryQuery::Dictionary::name);
+        if (selected != query_.freq_dicts_.end()) {
+          frequency_dictionary = selected->name;
+          frequency_descending = options.frequency_order == LookupFrequencyOrder::Descending;
+        }
+      }
+      break;
+    case LookupFrequencyOrder::Disabled:
+      break;
+  }
+  const std::optional<std::string_view> primary_reading =
+      options.primary_reading.has_value() && !options.primary_reading->empty() ? options.primary_reading : std::nullopt;
+  const size_t retained_count = std::min(results.size(), static_cast<size_t>(max_results));
+  auto middle_iter = std::ranges::next(results.begin(), static_cast<std::ptrdiff_t>(retained_count));
+  std::ranges::partial_sort(
+      results, middle_iter,
+      [primary_reading, frequency_dictionary, frequency_descending](const auto& a, const auto& b) {
+        if (primary_reading.has_value()) {
+          const std::string_view reading_a =
+              a.term.reading.empty() ? std::string_view(a.term.expression) : a.term.reading;
+          const std::string_view reading_b =
+              b.term.reading.empty() ? std::string_view(b.term.expression) : b.term.reading;
+          const bool primary_a = reading_a == *primary_reading;
+          const bool primary_b = reading_b == *primary_reading;
+          if (primary_a != primary_b) {
+            return primary_a;
+          }
+        }
 
-    if (a.term.score != b.term.score) {
-      return a.term.score > b.term.score;
-    }
+        auto len_a = utf8::distance(a.matched.begin(), a.matched.end());
+        auto len_b = utf8::distance(b.matched.begin(), b.matched.end());
+        if (len_a != len_b) {
+          return len_a > len_b;
+        }
 
-    auto a_reading_expr_match = a.term.expression == a.term.reading;
-    auto b_reading_expr_match = b.term.expression == b.term.reading;
-    return a_reading_expr_match > b_reading_expr_match;
-  });
+        auto steps_a = a.preprocessor_steps;
+        auto steps_b = b.preprocessor_steps;
+        if (steps_a != steps_b) {
+          return steps_a < steps_b;
+        }
 
-  if (results.size() > static_cast<size_t>(max_results)) {
-    results.resize(max_results);
+        auto trace_len_a = a.trace.size();
+        auto trace_len_b = b.trace.size();
+        if (trace_len_a != trace_len_b) {
+          return trace_len_a < trace_len_b;
+        }
+
+        auto match_a = a.term.expression == a.deinflected;
+        auto match_b = b.term.expression == b.deinflected;
+        if (match_a != match_b) {
+          return match_a > match_b;
+        }
+
+        if (frequency_dictionary.has_value()) {
+          const auto freq_a = get_freq_value_for_dict(a.term, *frequency_dictionary, frequency_descending);
+          const auto freq_b = get_freq_value_for_dict(b.term, *frequency_dictionary, frequency_descending);
+          if (freq_a.has_value() != freq_b.has_value()) {
+            return freq_a.has_value();
+          }
+          if (freq_a.has_value() && *freq_a != *freq_b) {
+            return frequency_descending ? *freq_a > *freq_b : *freq_a < *freq_b;
+          }
+        }
+
+        if (a.term.score != b.term.score) {
+          return a.term.score > b.term.score;
+        }
+
+        auto a_reading_expr_match = a.term.expression == a.term.reading;
+        auto b_reading_expr_match = b.term.expression == b.term.reading;
+        return a_reading_expr_match > b_reading_expr_match;
+      });
+
+  if (results.size() > retained_count) {
+    results.resize(retained_count);
   }
 
   for (auto& r : results) {

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -23,6 +23,10 @@
 #include "memory/memory.hpp"
 
 namespace {
+// The compressed size comes from the dictionary, so cap what a single glossary
+// may expand to before allocating for it.
+constexpr size_t MAX_GLOSSARY_BYTES = size_t{32} * 1024 * 1024;
+
 template <typename T>
 T read_val(const uint8_t*& addr) {
   T val;
@@ -35,6 +39,15 @@ std::string_view read_str(const uint8_t*& addr, uint32_t len) {
   std::string_view result(reinterpret_cast<const char*>(addr), len);
   addr += len;
   return result;
+}
+
+void append_redirect(std::vector<DictionaryRedirect>& redirects, DictionaryRedirect redirect) {
+  const bool duplicate = std::ranges::any_of(redirects, [&](const DictionaryRedirect& existing) {
+    return existing.form_of == redirect.form_of && existing.inflection_rules == redirect.inflection_rules;
+  });
+  if (!duplicate) {
+    redirects.push_back(std::move(redirect));
+  }
 }
 }
 
@@ -71,7 +84,9 @@ DictionaryQuery::Dictionary& DictionaryQuery::Dictionary::operator=(Dictionary&&
 
 void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
   int version = 0;
-  if (std::filesystem::is_regular_file(path + "/.hoshidicts_3")) {
+  if (std::filesystem::is_regular_file(path + "/.hoshidicts_4")) {
+    version = 4;
+  } else if (std::filesystem::is_regular_file(path + "/.hoshidicts_3")) {
     version = 3;
   } else if (std::filesystem::is_regular_file(path + "/.hoshidicts_2")) {
     version = 2;
@@ -167,7 +182,9 @@ std::vector<TermResult> DictionaryQuery::query(const std::string& expression) co
   auto results = query_raw(expression);
   for (auto& term : results) {
     materialize(term);
+    prune_empty_glossaries(term);
   }
+  std::erase_if(results, [](const TermResult& term) { return term.glossaries.empty(); });
   return results;
 }
 
@@ -213,16 +230,20 @@ std::vector<TermResult> DictionaryQuery::query_raw(const std::string& expression
       auto term_tag_size = read_val<uint8_t>(blob_addr);
       std::string_view term_tags = read_str(blob_addr, term_tag_size);
 
+      std::vector<DictionaryRedirect> redirects;
       if (data->version >= 2) {
         auto redirect_count = read_val<uint32_t>(blob_addr);
         for (uint32_t r = 0; r < redirect_count; r++) {
           auto form_of_len = read_val<uint32_t>(blob_addr);
-          read_str(blob_addr, form_of_len);
+          std::string_view form_of = read_str(blob_addr, form_of_len);
           auto rule_count = read_val<uint32_t>(blob_addr);
+          DictionaryRedirect redirect{.form_of = std::string(form_of)};
+          redirect.inflection_rules.reserve(rule_count);
           for (uint32_t j = 0; j < rule_count; j++) {
             auto rule_len = read_val<uint32_t>(blob_addr);
-            read_str(blob_addr, rule_len);
+            redirect.inflection_rules.emplace_back(read_str(blob_addr, rule_len));
           }
+          append_redirect(redirects, std::move(redirect));
         }
       }
 
@@ -231,12 +252,36 @@ std::vector<TermResult> DictionaryQuery::query_raw(const std::string& expression
         score = read_val<int32_t>(blob_addr);
       }
 
+      bool has_display_definitions = true;
+      if (data->version >= 4) {
+        has_display_definitions = read_val<uint8_t>(blob_addr) != 0;
+      }
+
       GlossaryEntry entry;
       entry.dict_name = name;
       entry.definition_tags = definition_tags;
       entry.term_tags = term_tags;
       entry.compressed_data = data->blobs.data + glossary_offset;
       entry.compressed_size = glossary_size;
+      entry.redirects = std::move(redirects);
+      entry.has_display_definitions = has_display_definitions;
+
+      if (data->version < 4) {
+        entry.glossary = decompress_glossary(entry.compressed_data, entry.compressed_size);
+        entry.materialized = true;
+        ParsedGlossary parsed_glossary;
+        if (yomitan_parser::parse_glossary(entry.glossary, parsed_glossary)) {
+          entry.glossary = std::move(parsed_glossary.display_json);
+          entry.has_display_definitions = parsed_glossary.has_display_definitions;
+          for (auto& redirect : parsed_glossary.redirects) {
+            append_redirect(entry.redirects,
+                            DictionaryRedirect{.form_of = std::move(redirect.form_of),
+                                               .inflection_rules = std::move(redirect.inflection_rules)});
+          }
+        } else {
+          entry.has_display_definitions = !entry.glossary.empty();
+        }
+      }
 
       auto [it, inserted] = term_map.try_emplace({expr, reading});
       if (inserted) {
@@ -528,7 +573,8 @@ std::string DictionaryQuery::decompress_glossary(const void* data, size_t size) 
   }
 
   unsigned long long decompressed_size = ZSTD_getFrameContentSize(data, size);
-  if (decompressed_size == ZSTD_CONTENTSIZE_ERROR || decompressed_size == ZSTD_CONTENTSIZE_UNKNOWN) {
+  if (decompressed_size == ZSTD_CONTENTSIZE_ERROR || decompressed_size == ZSTD_CONTENTSIZE_UNKNOWN ||
+      decompressed_size > MAX_GLOSSARY_BYTES) {
     return "";
   }
 
@@ -546,8 +592,15 @@ std::string DictionaryQuery::decompress_glossary(const void* data, size_t size) 
 
 void DictionaryQuery::materialize(TermResult& term) const {
   for (auto& g : term.glossaries) {
-    g.glossary = decompress_glossary(g.compressed_data, g.compressed_size);
+    if (!g.materialized) {
+      g.glossary = decompress_glossary(g.compressed_data, g.compressed_size);
+      g.materialized = true;
+    }
   }
+}
+
+void DictionaryQuery::prune_empty_glossaries(TermResult& term) {
+  std::erase_if(term.glossaries, [](const GlossaryEntry& glossary) { return !glossary.has_display_definitions; });
 }
 
 std::vector<char> DictionaryQuery::get_media_file(const std::string& dict_name, const std::string& media_path) const {

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -5,11 +5,14 @@
 #include <zstd.h>
 
 #include <algorithm>
+#include <array>
+#include <cctype>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <memory>
 #include <ranges>
 #include <string_view>
@@ -115,6 +118,16 @@ void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
   dict.data->blobs = memory::map_rd(path + "/blobs.bin");
   if (!dict.data->blobs) {
     return;
+  }
+
+  if (type == FREQ && freq_dicts_.empty()) {
+    if (summary.frequencyMode == "occurrence-based") {
+      primary_frequency_mode_ = FrequencyMode::Occurrence;
+    } else if (summary.frequencyMode == "rank-based") {
+      primary_frequency_mode_ = FrequencyMode::Rank;
+    } else {
+      primary_frequency_mode_ = infer_frequency_mode(*dict.data, summary.sourceLanguage);
+    }
   }
 
   dict.data->media = memory::map_rd(path + "/media.bin");
@@ -256,52 +269,123 @@ std::vector<TermResult> DictionaryQuery::query_raw(const std::string& expression
 void DictionaryQuery::query_freq(std::vector<TermResult>& terms) const {
   for (auto& term : terms) {
     for (const auto& [name, styles, data] : freq_dicts_) {
-      uint64_t offset_addr = data->table(term.expression);
-      if (offset_addr == 0) {
-        continue;
-      }
-      const uint8_t* index_addr = data->blobs.data + offset_addr;
-      auto count = read_val<uint32_t>(index_addr);
-
-      std::vector<Frequency> frequencies;
-      for (uint32_t i = 0; i < count; i++) {
-        auto offset = read_val<uint64_t>(index_addr);
-        const uint8_t* blob_addr = data->blobs.data + offset;
-
-        auto type = read_val<uint8_t>(blob_addr);
-        if (type != 1) {
-          continue;
-        }
-
-        auto expr_len = read_val<uint16_t>(blob_addr);
-        std::string_view expr = read_str(blob_addr, expr_len);
-        if (expr != term.expression) {
-          continue;
-        }
-
-        auto mode_len = read_val<uint8_t>(blob_addr);
-        std::string_view mode = read_str(blob_addr, mode_len);
-        if (mode != "freq") {
-          continue;
-        }
-
-        auto freq_data_size = read_val<uint32_t>(blob_addr);
-        std::string_view freq_data = read_str(blob_addr, freq_data_size);
-
-        ParsedFrequency parsed;
-        if (yomitan_parser::parse_frequency(freq_data, parsed)) {
-          if (!parsed.reading.empty() && parsed.reading != term.reading) {
-            continue;
-          }
-          frequencies.emplace_back(
-              Frequency{.value = parsed.value, .display_value = std::string(parsed.display_value)});
-        }
-      }
+      auto frequencies = query_frequencies(*data, term.expression, term.reading);
       if (!frequencies.empty()) {
         term.frequencies.emplace_back(FrequencyEntry{.dict_name = name, .frequencies = std::move(frequencies)});
       }
     }
   }
+}
+
+std::vector<Frequency> DictionaryQuery::query_frequencies(const DictionaryData& data, const std::string& expression,
+                                                          std::optional<std::string_view> reading) {
+  uint64_t offset_addr = data.table(expression);
+  if (offset_addr == 0) {
+    return {};
+  }
+  const uint8_t* index_addr = data.blobs.data + offset_addr;
+  auto count = read_val<uint32_t>(index_addr);
+
+  std::vector<Frequency> frequencies;
+  for (uint32_t i = 0; i < count; i++) {
+    auto offset = read_val<uint64_t>(index_addr);
+    const uint8_t* blob_addr = data.blobs.data + offset;
+
+    auto type = read_val<uint8_t>(blob_addr);
+    if (type != 1) {
+      continue;
+    }
+
+    auto expr_len = read_val<uint16_t>(blob_addr);
+    std::string_view expr = read_str(blob_addr, expr_len);
+    if (expr != expression) {
+      continue;
+    }
+
+    auto mode_len = read_val<uint8_t>(blob_addr);
+    std::string_view mode = read_str(blob_addr, mode_len);
+    if (mode != "freq") {
+      continue;
+    }
+
+    auto freq_data_size = read_val<uint32_t>(blob_addr);
+    std::string_view freq_data = read_str(blob_addr, freq_data_size);
+
+    ParsedFrequency parsed;
+    if (!yomitan_parser::parse_frequency(freq_data, parsed)) {
+      continue;
+    }
+    if (reading.has_value() && !parsed.reading.empty() && parsed.reading != *reading) {
+      continue;
+    }
+
+    Frequency frequency{.value = parsed.value, .display_value = std::move(parsed.display_value)};
+    const bool duplicate = std::ranges::any_of(frequencies, [&](const Frequency& existing) {
+      return existing.value == frequency.value && existing.display_value == frequency.display_value;
+    });
+    if (!duplicate) {
+      frequencies.push_back(std::move(frequency));
+    }
+  }
+  return frequencies;
+}
+
+DictionaryQuery::FrequencyMode DictionaryQuery::infer_frequency_mode(
+    const DictionaryData& data, const std::optional<std::string>& source_language) {
+  if (source_language.has_value() && !source_language->empty()) {
+    std::string normalized_language = *source_language;
+    std::ranges::transform(normalized_language, normalized_language.begin(),
+                           [](unsigned char character) { return static_cast<char>(std::tolower(character)); });
+    if (normalized_language != "ja") {
+      return FrequencyMode::Rank;
+    }
+  }
+
+  static constexpr std::array<std::string_view, 10> more_common_terms = {
+      "来る", "言う", "出る", "入る", "方", "男", "女", "今", "何", "時",
+  };
+  static constexpr std::array<std::string_view, 10> less_common_terms = {
+      "行なう", "論じる", "過す", "行方", "人口", "猫", "犬", "滝", "理", "暁",
+  };
+
+  struct Details {
+    bool has_value = false;
+    int min_value = std::numeric_limits<int>::max();
+    int max_value = std::numeric_limits<int>::min();
+  };
+
+  auto get_details = [&](std::string_view term) {
+    Details details;
+    for (const auto& frequency : query_frequencies(data, std::string(term), std::nullopt)) {
+      details.has_value = true;
+      details.min_value = std::min(details.min_value, frequency.value);
+      details.max_value = std::max(details.max_value, frequency.value);
+    }
+    return details;
+  };
+
+  std::array<Details, more_common_terms.size()> common_details;
+  std::array<Details, less_common_terms.size()> rare_details;
+  std::ranges::transform(more_common_terms, common_details.begin(), get_details);
+  std::ranges::transform(less_common_terms, rare_details.begin(), get_details);
+
+  int result = 0;
+  // Widened so the differences below cannot overflow at the int extremes.
+  auto sign = [](long long value) { return (value > 0) - (value < 0); };
+  for (const auto& common : common_details) {
+    if (!common.has_value) {
+      continue;
+    }
+    for (const auto& rare : rare_details) {
+      if (!rare.has_value) {
+        continue;
+      }
+      result += sign(static_cast<long long>(common.max_value) - rare.min_value) +
+                sign(static_cast<long long>(common.min_value) - rare.max_value);
+    }
+  }
+
+  return result > 0 ? FrequencyMode::Occurrence : FrequencyMode::Rank;
 }
 
 void DictionaryQuery::query_pitch(std::vector<TermResult>& terms) const {


### PR DESCRIPTION
**Draft, because it bumps the on-disk format and that forces every user to re-import.** The code works and is verified below; I'd rather you decide whether the migration is worth it than merge it and find out.

Stacked on #26. Read the last commit only.

## The problem

Yomitan treats a top-level array in a term's definitions list as dictionary deinflection metadata — `[form_of, [inflection_rules]]` — never as a displayable definition. It follows the pointer and hides the tuple. Hoshidicts does neither: the tuple is stored as part of the glossary and the target is never queried.

This is not a rare shape. **136,668 of Jitendex's 433,885 entries (31%) carry one**, all in exactly this form:

```json
["Ｎ響", ["redirected from Ｎ響"]]
```

## Before / after

A two-entry dictionary where 喰べる is a pure redirect to 食べる, in Jitendex's exact shape. `hoshidicts-cli lookup RedirTest 喰べる`:

**Current:**
```
1 results
喰べる たべる
[{"type": "structured-content", … "content": "食べる"}}}, ["食べる", ["redirected from 喰べる"]]]
```
One result. The raw tuple is part of the glossary the front end is handed, and 食べる's actual definition is never returned.

**With this change:**
```
2 results
喰べる たべる
[{"type": "structured-content", … "content": "食べる"}}}]

喰べる
  redirected from 喰べる
食べる たべる
["to eat"]
```
The tuple is gone from the glossary, the target is followed, and the inflection rule appears in the trace.

## What it does

- `parse_glossary` splits a term's definitions into the JSON that should be displayed and the redirect tuples. Only schema-valid, non-empty tuples become redirects; malformed arrays are stripped rather than followed, and non-array definitions pass through untouched with no numeric re-encoding.
- The importer writes the redirects where the format already reserves a `uint32_t` zero, plus one byte recording whether the entry had any displayable definitions.
- Lookup follows each source redirect exactly once, queries all enabled term dictionaries, does not apply the source POS condition to targets, and does not recurse into redirects on those targets — which is what Yomitan does.
- Entries left with no displayable definitions are pruned instead of surfacing empty.

## The cost, and it is the reason this is a draft

The per-term record grows a byte, so `.hoshidicts_3` becomes `.hoshidicts_4`. Existing dictionaries are still read — version 3 is detected and its records parsed as before — but they will not have redirect data until re-imported, so users get the old behaviour until they do. If you would rather stage this behind a format migration, or land it alongside another format change, that is entirely reasonable and I am happy to rework it.

## Scope notes

I deliberately kept two things out that were tangled up with this work in my tree:

- the narrowing guards in `process_term_bank` — those are #25, and this branch writes the new redirect fields with plain casts so the two don't collide;
- `KanjiResultBudget` — that's #22.

One thing I did keep: `MAX_GLOSSARY_BYTES`, a 32 MiB cap on what a single glossary may decompress to. The compressed size is dictionary-controlled and this code path now runs for every entry, so it belongs with the change. Say the word and I'll split it out.

The `ZSTD_CCtx` becomes a `unique_ptr` because `parse_glossary` introduces a throw site inside its lifetime.

## Verification

GCC 14.4, Release, `-DHOSHIDICTS_CLI=ON`: builds clean, 0 errors, 0 warnings. The before/after above is from two CLI binaries built from clean checkouts of #26's branch and this one.

Needs `-include cstdint` until #21 lands.