### PR TITLE
feat: single-file .hoshi container, packer and verifier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ add_subdirectory(external/utf8proc)
 add_library(hoshidicts
     src/hash/hash.cpp
     src/hash/bloom.cpp
+    src/container.cpp
     src/importer.cpp
     src/memory/memory.cpp
     src/zip/zip.cpp

--- a/README.md
+++ b/README.md
@@ -67,6 +67,76 @@ Follows a parsing strategy similar to Yomitan. Substrings of `lookup_string` are
 
 Results are filtered by part-of-speech tags defined in dictionaries, or added directly if none are present. The results are sorted by matched length first, then by preprocessing steps, then deinflection trace length and finally by frequency.
 
+## Container format
+
+A `.hoshi` file is a single-file wrapper around the directory an import produces. It concatenates the payload files byte for byte, prefixed by a header and a section table, so a dictionary can be mapped and queried without being extracted first.
+
+No payload byte changes. Every offset inside `blobs.bin`, `media.bin`, `hash.table` and `bloom.filter` is already relative to the start of its own file, so a byte-identical copy placed at an arbitrary offset works unchanged as long as the consumer is handed the right base pointer and the exact length.
+
+All fields are fixed-width little-endian. Structs are never written directly.
+
+### Header — 64 bytes at offset 0
+
+| Off | Type | Meaning |
+| --- | --- | --- |
+| 0 | `char[8]` | magic `HOSHIDCT` |
+| 8 | `u32` | container version, currently 1 |
+| 12 | `u32` | header size, 64 |
+| 16 | `u32` | payload version, 3 or 4 |
+| 20 | `u32` | flags, bit 0 `LITTLE_ENDIAN` must be set |
+| 24 | `u32` | section count, 1 to 32 |
+| 28 | `u32` | section descriptor size, 32 |
+| 32 | `u64` | section table offset, 64 |
+| 40 | `u64` | exact container file size |
+| 48 | `u64` | reserved, zero |
+| 56 | `u64` | reserved, zero |
+
+The payload version is what the `.hoshidicts_N` marker file encodes in a directory. The marker itself is not stored.
+
+### Section descriptor — 32 bytes
+
+| Off | Type | Meaning |
+| --- | --- | --- |
+| 0 | `u32` | section type |
+| 4 | `u32` | flags, bit 0 `REQUIRED` |
+| 8 | `u64` | offset, multiple of 64 |
+| 16 | `u64` | length, exact payload length without padding |
+| 24 | `u64` | XXH3-64 of the section bytes |
+
+Descriptors are ordered by section type. Sections are laid out in the same order and each one starts on a 64-byte boundary; the gap in between is zero-filled. 64 rather than 8 because `bloom::load()` reads a `uint64_t` at section offset 0 and +8 through a `reinterpret_cast`, and `linear::load()` does the same with a `uint32_t`. Padding is never inside a section view: both loaders reject a size that is not exactly the size derived from the bytes.
+
+### Sections
+
+| ID | Name | Source file | Required |
+| --- | --- | --- | --- |
+| 1 | `INDEX` | `index.json` | yes |
+| 2 | `BLOBS` | `blobs.bin` | yes |
+| 3 | `HASH_TABLE` | `hash.table` | yes |
+| 4 | `BLOOM_FILTER` | `bloom.filter` | yes |
+| 5 | `ZSTD_DICT` | `dict.zstd` | payload v4 only |
+| 6 | `MEDIA` | `media.bin` | no |
+| 7 | `MEDIA_INDEX` | `media.idx` | iff `MEDIA` is present |
+
+Types 8 to 63 are reserved. An unknown type without `REQUIRED` is ignored, an unknown type with `REQUIRED` makes the container unreadable.
+
+Payload versions 1 and 2 are out of scope: they may carry a separate `styles.css`, which has no section, and no v1 or v2 dictionary is redistributed.
+
+### Reading
+
+`open()` validates the header and the section table only: magic, container version, header size, descriptor size and table offset; the `LITTLE_ENDIAN` flag; payload version 3 or 4; section count 1 to 32; every offset a multiple of 64 that clears the header and table; no empty section, no `offset + length` overflow, everything within the declared file size; the declared file size equals the real file size; no duplicate types and no overlapping ranges; `INDEX`, `BLOBS`, `HASH_TABLE` and `BLOOM_FILTER` present; `ZSTD_DICT` present iff the payload version is 4; `MEDIA_INDEX` present iff `MEDIA` is present.
+
+It deliberately does not hash payloads; that would defeat the point of mapping a 100 MB file lazily. `verify()` does, and is meant for CI and for a one-time check after a download. Containers are recognised by their magic bytes, not by their extension.
+
+`read_index()` returns the `INDEX` section verbatim — the summary the import wrote, carrying `title`, `revision` and the entry `counts`. That is enough to identify a container, notice that a newer build exists, and tell a term dictionary from a kanji or IPA one, without mapping the payload or being told what the file is.
+
+### Writing
+
+`pack()` streams each source file through a fixed buffer while folding its XXH3, so its memory use is constant in the size of the dictionary. It writes `<output>.tmp`, backpatches the header and the table, reopens the result, runs the full `verify()`, and only then renames it into place.
+
+Given the same input directory the output is byte for byte identical. The *importer* is not reproducible, though — `index.json` carries an `importDate` — so importing the same zip twice and packing both produces two different containers. Publish checksums of what was actually built rather than promising reproducibility.
+
+The `LITTLE_ENDIAN` flag is validated but the reader still decodes with the host byte order, so a big-endian host would misread a container. That matches the rest of the engine, which already assumes little-endian for `blobs.bin`. The flag exists so a future big-endian reader can reject rather than silently misparse.
+
 ## Acknowledgements
 
 - [Yomitan](https://github.com/yomidevs/yomitan): Dictionary format, Japanese deinflection rules and descriptions, Japanese preprocessor | GPL-3.0

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -8,6 +8,7 @@
 
 #include "../src/path_utils.hpp"
 #include "../src/text_processor/text_processor.hpp"
+#include "hoshidicts/container.hpp"
 #include "hoshidicts/deinflector.hpp"
 #include "hoshidicts/importer.hpp"
 #include "hoshidicts/lookup.hpp"
@@ -16,6 +17,9 @@
 void print_usage(const char* program) {
   std::cout << std::format("Usage:\n");
   std::cout << std::format("{} import <path/to/dictionary.zip>\n", program);
+  std::cout << std::format("{} pack <path/to/dictionary> <path/to/output.hoshi>\n", program);
+  std::cout << std::format("{} verify <path/to/dictionary.hoshi>\n", program);
+  std::cout << std::format("{} index <path/to/dictionary.hoshi>\n", program);
   std::cout << std::format("{} deinflect <word>\n", program);
   std::cout << std::format("{} preprocess <word>\n", program);
   std::cout << std::format("{} query <path/to/dictionary> <word>\n", program);
@@ -44,6 +48,43 @@ void cmd_import(const std::string& path) {
   } else {
     std::cout << std::format("could not import dictionary: {}\n", result.error);
   }
+}
+
+bool cmd_pack(const std::string& dictionary_dir, const std::string& output_path) {
+  const auto result = dictionary_container::pack(dictionary_dir, output_path);
+  if (!result.ok) {
+    std::cout << std::format("could not pack dictionary: {}\n", result.error);
+    return false;
+  }
+
+  std::cout << std::format("bytes: {}\n", result.bytes);
+  return true;
+}
+
+bool cmd_verify(const std::string& container_path) {
+  const auto result = dictionary_container::verify(container_path);
+  if (!result.ok) {
+    std::cout << std::format("could not verify container: {}\n", result.error);
+    return false;
+  }
+
+  std::cout << std::format("payload_version: {}\n", result.container.payload_version);
+  std::cout << std::format("section_count: {}\n", result.container.sections.size());
+  for (const auto& section : result.container.sections) {
+    std::cout << std::format("section: {} length: {}\n", section.type, section.length);
+  }
+  return true;
+}
+
+bool cmd_index(const std::string& container_path) {
+  const auto result = dictionary_container::read_index(container_path);
+  if (!result.ok) {
+    std::cout << std::format("could not read container index: {}\n", result.error);
+    return false;
+  }
+
+  std::cout << result.json << "\n";
+  return true;
 }
 
 void cmd_deinflect(const std::string& inflected) {
@@ -190,9 +231,16 @@ int main(int argc, char* argv[]) {
 
   const auto begin = std::chrono::steady_clock::now();
   std::string_view command = argv[1];
+  int status = 0;
 
   if (command == "import" && argc >= 3) {
     cmd_import(argv[2]);
+  } else if (command == "pack" && argc >= 4) {
+    status = cmd_pack(argv[2], argv[3]) ? 0 : 1;
+  } else if (command == "verify" && argc >= 3) {
+    status = cmd_verify(argv[2]) ? 0 : 1;
+  } else if (command == "index" && argc >= 3) {
+    status = cmd_index(argv[2]) ? 0 : 1;
   } else if (command == "deinflect" && argc >= 3) {
     cmd_deinflect(argv[2]);
   } else if (command == "preprocess" && argc >= 3) {
@@ -218,5 +266,5 @@ int main(int argc, char* argv[]) {
   std::chrono::duration<double, std::milli> duration = end - begin;
   std::cout << std::format("runtime: {}ms\n", duration.count());
 
-  return 0;
+  return status;
 }

--- a/include/hoshidicts.h
+++ b/include/hoshidicts.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "hoshidicts/container.hpp"
 #include "hoshidicts/deinflector.hpp"
 #include "hoshidicts/importer.hpp"
 #include "hoshidicts/lookup.hpp"

--- a/include/hoshidicts/container.hpp
+++ b/include/hoshidicts/container.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace dictionary_container {
+enum SectionType : uint32_t {
+  INDEX = 1,
+  BLOBS = 2,
+  HASH_TABLE = 3,
+  BLOOM_FILTER = 4,
+  ZSTD_DICT = 5,
+  MEDIA = 6,
+  MEDIA_INDEX = 7,
+};
+
+struct Section {
+  uint32_t type = 0;
+  uint32_t flags = 0;
+  uint64_t offset = 0;
+  uint64_t length = 0;
+  uint64_t checksum = 0;
+};
+
+struct Container {
+  uint32_t payload_version = 0;
+  uint64_t size = 0;
+  std::vector<Section> sections;
+
+  const Section* find(uint32_t type) const;
+};
+
+struct OpenResult {
+  bool ok = false;
+  Container container;
+  std::string error;
+};
+
+struct PackResult {
+  bool ok = false;
+  uint64_t bytes = 0;
+  std::string error;
+};
+
+struct VerifyResult {
+  bool ok = false;
+  Container container;
+  std::string error;
+};
+
+struct IndexResult {
+  bool ok = false;
+  std::string json;
+  std::string error;
+};
+
+OpenResult open(const std::string& path_utf8);
+
+PackResult pack(const std::string& dictionary_dir_utf8, const std::string& output_path_utf8);
+
+VerifyResult verify(const std::string& path_utf8);
+
+IndexResult read_index(const std::string& path_utf8);
+}

--- a/include/hoshidicts_c.h
+++ b/include/hoshidicts_c.h
@@ -30,6 +30,11 @@ uint64_t hd_import_result_media_count(const hd_import_result* r);
 
 const char* hd_import_result_error(const hd_import_result* r);
 
+int hd_container_pack(const char* dictionary_dir, const char* output_path, char** error);
+int hd_container_verify(const char* container_path, uint32_t* payload_version, char** error);
+int hd_container_index(const char* container_path, char** index_json, char** error);
+void hd_container_string_free(char* value);
+
 // deinflector
 typedef struct hd_deinflector hd_deinflector;
 

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -1,0 +1,410 @@
+#include "hoshidicts/container.hpp"
+
+#include <xxh3.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstring>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <glaze/glaze.hpp>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "hoshidicts/importer.hpp"
+#include "path_utils.hpp"
+
+namespace dictionary_container {
+namespace {
+constexpr char MAGIC[8] = {'H', 'O', 'S', 'H', 'I', 'D', 'C', 'T'};
+constexpr uint32_t CONTAINER_VERSION = 1;
+constexpr uint32_t HEADER_SIZE = 64;
+constexpr uint32_t DESCRIPTOR_SIZE = 32;
+constexpr uint32_t MAX_SECTIONS = 32;
+constexpr uint64_t ALIGNMENT = 64;
+constexpr uint32_t LITTLE_ENDIAN_FLAG = 1U << 0;
+constexpr uint32_t REQUIRED_FLAG = 1U << 0;
+constexpr size_t CHUNK_SIZE = 1U << 20;
+
+template <typename T>
+T read_val(const uint8_t*& addr) {
+  T val;
+  std::memcpy(&val, addr, sizeof(T));
+  addr += sizeof(T);
+  return val;
+}
+
+bool known_type(uint32_t type) { return type >= INDEX && type <= MEDIA_INDEX; }
+
+OpenResult open_failed(std::string error) { return {.error = std::move(error)}; }
+
+PackResult pack_failed(std::string error) { return {.error = std::move(error)}; }
+
+VerifyResult verify_failed(std::string error) { return {.error = std::move(error)}; }
+
+IndexResult index_failed(std::string error) { return {.error = std::move(error)}; }
+
+constexpr uint64_t align_up(uint64_t value) { return (value + ALIGNMENT - 1) / ALIGNMENT * ALIGNMENT; }
+
+bool digest_section(std::istream& in, std::ostream* out, std::vector<char>& chunk, uint64_t length,
+                    uint64_t& checksum) {
+  const std::unique_ptr<XXH3_state_t, decltype(&XXH3_freeState)> state(XXH3_createState(), XXH3_freeState);
+  if (!state || XXH3_64bits_reset(state.get()) == XXH_ERROR) {
+    return false;
+  }
+
+  uint64_t left = length;
+  while (left > 0) {
+    const auto step = static_cast<std::streamsize>(std::min<uint64_t>(left, chunk.size()));
+    if (!in.read(chunk.data(), step)) {
+      return false;
+    }
+    if (out != nullptr && !out->write(chunk.data(), step)) {
+      return false;
+    }
+    XXH3_64bits_update(state.get(), chunk.data(), static_cast<size_t>(step));
+    left -= static_cast<uint64_t>(step);
+  }
+
+  checksum = XXH3_64bits_digest(state.get());
+  return true;
+}
+
+bool write_zeros(std::ostream& out, uint64_t count) {
+  static constexpr std::array<char, ALIGNMENT> zeros{};
+  while (count > 0) {
+    const auto step = static_cast<std::streamsize>(std::min<uint64_t>(count, zeros.size()));
+    if (!out.write(zeros.data(), step)) {
+      return false;
+    }
+    count -= static_cast<uint64_t>(step);
+  }
+  return true;
+}
+
+template <typename T>
+void write_val(uint8_t*& addr, T val) {
+  std::memcpy(addr, &val, sizeof(T));
+  addr += sizeof(T);
+}
+
+struct PlannedSection {
+  const char* name;
+  Section section;
+};
+
+std::vector<uint8_t> encode_header(uint32_t payload_version, uint64_t total_size,
+                                   const std::vector<PlannedSection>& planned) {
+  std::vector<uint8_t> encoded(HEADER_SIZE + planned.size() * DESCRIPTOR_SIZE, 0);
+  uint8_t* addr = encoded.data();
+
+  std::memcpy(addr, MAGIC, sizeof(MAGIC));
+  addr += sizeof(MAGIC);
+  write_val<uint32_t>(addr, CONTAINER_VERSION);
+  write_val<uint32_t>(addr, HEADER_SIZE);
+  write_val<uint32_t>(addr, payload_version);
+  write_val<uint32_t>(addr, LITTLE_ENDIAN_FLAG);
+  write_val<uint32_t>(addr, static_cast<uint32_t>(planned.size()));
+  write_val<uint32_t>(addr, DESCRIPTOR_SIZE);
+  write_val<uint64_t>(addr, HEADER_SIZE);
+  write_val<uint64_t>(addr, total_size);
+  write_val<uint64_t>(addr, 0);
+  write_val<uint64_t>(addr, 0);
+
+  for (const auto& [name, section] : planned) {
+    write_val<uint32_t>(addr, section.type);
+    write_val<uint32_t>(addr, section.flags);
+    write_val<uint64_t>(addr, section.offset);
+    write_val<uint64_t>(addr, section.length);
+    write_val<uint64_t>(addr, section.checksum);
+  }
+
+  return encoded;
+}
+
+std::string write_container(const std::filesystem::path& dir, const std::filesystem::path& output,
+                            uint32_t payload_version, std::vector<PlannedSection>& planned, uint64_t total_size) {
+  std::ofstream out(output, std::ios::binary | std::ios::trunc);
+  if (!out) {
+    return std::format("cannot create {}", path_utils::to_utf8(output));
+  }
+
+  std::vector<char> chunk(CHUNK_SIZE);
+  uint64_t written = 0;
+  for (auto& [name, section] : planned) {
+    if (!write_zeros(out, section.offset - written)) {
+      return "cannot pad the container";
+    }
+    std::ifstream in(dir / name, std::ios::binary);
+    if (!in || !digest_section(in, &out, chunk, section.length, section.checksum)) {
+      return std::format("cannot copy {} into the container", name);
+    }
+    written = section.offset + section.length;
+  }
+
+  const std::vector<uint8_t> header = encode_header(payload_version, total_size, planned);
+  out.seekp(0);
+  if (!out.write(reinterpret_cast<const char*>(header.data()), static_cast<std::streamsize>(header.size()))) {
+    return "cannot write the container header";
+  }
+  out.close();
+  return out ? "" : "cannot finish writing the container";
+}
+}
+
+const Section* Container::find(uint32_t type) const {
+  const auto it = std::ranges::find(sections, type, &Section::type);
+  return it == sections.end() ? nullptr : &*it;
+}
+
+OpenResult open(const std::string& path_utf8) {
+  const std::filesystem::path path = path_utils::from_utf8(path_utf8);
+
+  std::error_code ec;
+  const uintmax_t actual_size = std::filesystem::file_size(path, ec);
+  if (ec) {
+    return open_failed(std::format("cannot read {}", path_utf8));
+  }
+
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    return open_failed(std::format("cannot open {}", path_utf8));
+  }
+
+  std::array<uint8_t, HEADER_SIZE> header{};
+  if (!in.read(reinterpret_cast<char*>(header.data()), header.size())) {
+    return open_failed("truncated container header");
+  }
+
+  const uint8_t* addr = header.data();
+  if (std::memcmp(addr, MAGIC, sizeof(MAGIC)) != 0) {
+    return open_failed(std::format("{} is not a .hoshi container", path_utf8));
+  }
+  addr += sizeof(MAGIC);
+
+  const auto container_version = read_val<uint32_t>(addr);
+  const auto header_size = read_val<uint32_t>(addr);
+  const auto payload_version = read_val<uint32_t>(addr);
+  const auto flags = read_val<uint32_t>(addr);
+  const auto section_count = read_val<uint32_t>(addr);
+  const auto descriptor_size = read_val<uint32_t>(addr);
+  const auto table_offset = read_val<uint64_t>(addr);
+  const auto declared_size = read_val<uint64_t>(addr);
+
+  if (container_version != CONTAINER_VERSION) {
+    return open_failed(std::format("unsupported container version {}", container_version));
+  }
+  if (header_size != HEADER_SIZE || descriptor_size != DESCRIPTOR_SIZE || table_offset != HEADER_SIZE) {
+    return open_failed("unexpected container header layout");
+  }
+  if ((flags & LITTLE_ENDIAN_FLAG) == 0) {
+    return open_failed("container is not little-endian");
+  }
+  if (payload_version < 3 || payload_version > 4) {
+    return open_failed(std::format("unsupported payload version {}", payload_version));
+  }
+  if (section_count == 0 || section_count > MAX_SECTIONS) {
+    return open_failed(std::format("section count {} out of range", section_count));
+  }
+  if (declared_size != actual_size) {
+    return open_failed(std::format("container declares {} bytes but is {}", declared_size, actual_size));
+  }
+
+  std::vector<uint8_t> table(static_cast<size_t>(section_count) * DESCRIPTOR_SIZE);
+  if (!in.read(reinterpret_cast<char*>(table.data()), static_cast<std::streamsize>(table.size()))) {
+    return open_failed("truncated container section table");
+  }
+  const uint64_t payload_start = HEADER_SIZE + table.size();
+
+  Container container;
+  container.payload_version = payload_version;
+  container.size = declared_size;
+
+  addr = table.data();
+  for (uint32_t i = 0; i < section_count; i++) {
+    Section section;
+    section.type = read_val<uint32_t>(addr);
+    section.flags = read_val<uint32_t>(addr);
+    section.offset = read_val<uint64_t>(addr);
+    section.length = read_val<uint64_t>(addr);
+    section.checksum = read_val<uint64_t>(addr);
+
+    if (!known_type(section.type) && (section.flags & REQUIRED_FLAG) != 0) {
+      return open_failed(std::format("unknown required section type {}", section.type));
+    }
+    if (container.find(section.type) != nullptr) {
+      return open_failed(std::format("duplicate section type {}", section.type));
+    }
+    if (section.offset % ALIGNMENT != 0) {
+      return open_failed(std::format("section {} is not 64-byte aligned", section.type));
+    }
+    if (section.offset < payload_start) {
+      return open_failed(std::format("section {} overlaps the container header", section.type));
+    }
+    if (section.length == 0) {
+      return open_failed(std::format("section {} is empty", section.type));
+    }
+    if (section.offset > declared_size || section.length > declared_size - section.offset) {
+      return open_failed(std::format("section {} runs past the end of the container", section.type));
+    }
+    container.sections.push_back(section);
+  }
+
+  auto ordered = container.sections;
+  std::ranges::sort(ordered, {}, &Section::offset);
+  for (size_t i = 1; i < ordered.size(); i++) {
+    if (ordered[i].offset < ordered[i - 1].offset + ordered[i - 1].length) {
+      return open_failed(std::format("sections {} and {} overlap", ordered[i - 1].type, ordered[i].type));
+    }
+  }
+
+  for (const uint32_t type : {INDEX, BLOBS, HASH_TABLE, BLOOM_FILTER}) {
+    if (container.find(type) == nullptr) {
+      return open_failed(std::format("missing required section type {}", type));
+    }
+  }
+  if ((container.find(ZSTD_DICT) != nullptr) != (payload_version >= 4)) {
+    return open_failed("the zstd dictionary section does not match the payload version");
+  }
+  if ((container.find(MEDIA) != nullptr) != (container.find(MEDIA_INDEX) != nullptr)) {
+    return open_failed("media and media index must either both be present or both be absent");
+  }
+
+  return {.ok = true, .container = std::move(container)};
+}
+
+PackResult pack(const std::string& dictionary_dir_utf8, const std::string& output_path_utf8) {
+  const std::filesystem::path dir = path_utils::from_utf8(dictionary_dir_utf8);
+
+  uint32_t payload_version = 0;
+  if (std::filesystem::is_regular_file(dir / ".hoshidicts_4")) {
+    payload_version = 4;
+  } else if (std::filesystem::is_regular_file(dir / ".hoshidicts_3")) {
+    payload_version = 3;
+  } else {
+    return pack_failed(std::format("{} is not an imported dictionary of payload version 3 or 4", dictionary_dir_utf8));
+  }
+
+  std::ifstream index(dir / "index.json", std::ios::binary);
+  if (!index) {
+    return pack_failed("cannot read index.json");
+  }
+  const std::string buf(std::istreambuf_iterator<char>(index), {});
+  Summary summary;
+  if (glz::read<glz::opts{.error_on_unknown_keys = false}>(summary, buf)) {
+    return pack_failed("index.json is not a dictionary summary");
+  }
+
+  std::vector<PlannedSection> planned = {
+      {"index.json", {.type = INDEX}},
+      {"blobs.bin", {.type = BLOBS}},
+      {"hash.table", {.type = HASH_TABLE}},
+      {"bloom.filter", {.type = BLOOM_FILTER}},
+  };
+  if (payload_version >= 4) {
+    planned.push_back({"dict.zstd", {.type = ZSTD_DICT}});
+  }
+  if (std::filesystem::exists(dir / "media.bin")) {
+    planned.push_back({"media.bin", {.type = MEDIA}});
+    planned.push_back({"media.idx", {.type = MEDIA_INDEX}});
+  }
+
+  uint64_t offset = align_up(HEADER_SIZE + planned.size() * DESCRIPTOR_SIZE);
+  for (auto& [name, section] : planned) {
+    std::error_code ec;
+    const uintmax_t size = std::filesystem::file_size(dir / name, ec);
+    if (ec || size == 0) {
+      return pack_failed(std::format("{} is missing or empty", name));
+    }
+    section.flags = REQUIRED_FLAG;
+    section.offset = offset;
+    section.length = size;
+    offset = align_up(offset + size);
+  }
+  const uint64_t total_size = planned.back().section.offset + planned.back().section.length;
+
+  const std::string tmp_utf8 = output_path_utf8 + ".tmp";
+  const std::filesystem::path tmp = path_utils::from_utf8(tmp_utf8);
+
+  std::string error = write_container(dir, tmp, payload_version, planned, total_size);
+  if (error.empty()) {
+    const VerifyResult verified = verify(tmp_utf8);
+    if (!verified.ok) {
+      error = std::format("the packed container failed verification: {}", verified.error);
+    }
+  }
+
+  std::error_code ec;
+  if (!error.empty()) {
+    std::filesystem::remove(tmp, ec);
+    return pack_failed(std::move(error));
+  }
+
+  const std::filesystem::path output = path_utils::from_utf8(output_path_utf8);
+  std::filesystem::rename(tmp, output, ec);
+  if (ec) {
+    std::filesystem::remove(output, ec);
+    std::filesystem::rename(tmp, output, ec);
+  }
+  if (ec) {
+    std::filesystem::remove(tmp, ec);
+    return pack_failed(std::format("cannot move the container to {}", output_path_utf8));
+  }
+
+  return {.ok = true, .bytes = total_size};
+}
+
+VerifyResult verify(const std::string& path_utf8) {
+  OpenResult opened = open(path_utf8);
+  if (!opened.ok) {
+    return verify_failed(std::move(opened.error));
+  }
+
+  std::ifstream in(path_utils::from_utf8(path_utf8), std::ios::binary);
+  if (!in) {
+    return verify_failed(std::format("cannot open {}", path_utf8));
+  }
+
+  std::vector<char> chunk(CHUNK_SIZE);
+  for (const Section& section : opened.container.sections) {
+    in.seekg(static_cast<std::streamoff>(section.offset));
+    uint64_t checksum = 0;
+    if (!digest_section(in, nullptr, chunk, section.length, checksum)) {
+      return verify_failed(std::format("cannot read section {}", section.type));
+    }
+    if (checksum != section.checksum) {
+      return verify_failed(std::format("section {} does not match its checksum", section.type));
+    }
+  }
+
+  return {.ok = true, .container = std::move(opened.container)};
+}
+
+IndexResult read_index(const std::string& path_utf8) {
+  const OpenResult opened = open(path_utf8);
+  if (!opened.ok) {
+    return index_failed(opened.error);
+  }
+
+  const Section* section = opened.container.find(INDEX);
+  if (section == nullptr) {
+    return index_failed("the container has no index section");
+  }
+
+  std::ifstream in(path_utils::from_utf8(path_utf8), std::ios::binary);
+  if (!in) {
+    return index_failed(std::format("cannot open {}", path_utf8));
+  }
+
+  std::string json(section->length, '\0');
+  in.seekg(static_cast<std::streamoff>(section->offset));
+  if (!in.read(json.data(), static_cast<std::streamsize>(json.size()))) {
+    return index_failed("cannot read the index section");
+  }
+
+  return {.ok = true, .json = std::move(json)};
+}
+}

--- a/src/hash/bloom.cpp
+++ b/src/hash/bloom.cpp
@@ -14,13 +14,20 @@ constexpr uint64_t num_hashes = 7;
 }
 
 bool bloom::load(const uint8_t* ptr, size_t size) {
-  uint64_t num_bits = *reinterpret_cast<const uint64_t*>(ptr);
-  if (size != 2 * sizeof(uint64_t) + num_bits / 8) {
+  if (size < 2 * sizeof(uint64_t)) {
     return false;
   }
-  num_hashes_ = *reinterpret_cast<const uint64_t*>(ptr + sizeof(uint64_t));
+  uint64_t num_bits;
+  std::memcpy(&num_bits, ptr, sizeof(num_bits));
+  if (num_bits == 0 || !std::has_single_bit(num_bits) || num_bits % 8 != 0) {
+    return false;
+  }
+  if (size - 2 * sizeof(uint64_t) != num_bits / 8) {
+    return false;
+  }
+  std::memcpy(&num_hashes_, ptr + sizeof(uint64_t), sizeof(num_hashes_));
   mask_ = num_bits - 1;
-  bits_ = reinterpret_cast<const uint64_t*>(ptr + 2 * sizeof(uint64_t));
+  bits_ = ptr + 2 * sizeof(uint64_t);
   return true;
 }
 
@@ -36,7 +43,7 @@ void bloom::build_to_file(const std::vector<uint64_t>& hashes, const std::filesy
 
   std::memcpy(out.data, &num_bits, sizeof(uint64_t));
   std::memcpy(out.data + sizeof(uint64_t), &num_hashes, sizeof(uint64_t));
-  auto* bits = reinterpret_cast<uint64_t*>(out.data + 2 * sizeof(uint64_t));
+  uint8_t* bits = out.data + 2 * sizeof(uint64_t);
   std::memset(bits, 0, bits_size);
 
   for (uint64_t h : hashes) {
@@ -44,7 +51,7 @@ void bloom::build_to_file(const std::vector<uint64_t>& hashes, const std::filesy
     auto h2 = static_cast<uint32_t>(h >> 32);
     for (uint64_t k = 0; k < num_hashes; k++) {
       uint64_t bit = (h1 + k * h2) & mask;
-      bits[bit >> 6] |= 1ULL << (bit & 63);
+      bits[bit >> 3] |= 1U << (bit & 7);
     }
   }
 

--- a/src/hash/bloom.hpp
+++ b/src/hash/bloom.hpp
@@ -1,5 +1,7 @@
 #pragma once
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <filesystem>
 #include <vector>
 
@@ -14,7 +16,7 @@ class bloom {
     auto h2 = static_cast<uint32_t>(h >> 32);
     for (uint64_t k = 0; k < num_hashes_; k++) {
       uint64_t bit = (h1 + k * h2) & mask_;
-      if (!(bits_[bit >> 6] & (1ULL << (bit & 63)))) {
+      if ((bits_[bit >> 3] & (1U << (bit & 7))) == 0) {
         return false;
       }
     }
@@ -24,6 +26,6 @@ class bloom {
  private:
   uint64_t mask_ = 0;
   uint64_t num_hashes_ = 0;
-  const uint64_t* bits_ = nullptr;
+  const uint8_t* bits_ = nullptr;
 };
 }

--- a/src/hash/hash.cpp
+++ b/src/hash/hash.cpp
@@ -4,70 +4,90 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 #include <cstring>
-#include <memory>
 #include <stdexcept>
+#include <vector>
 
 #include "../memory/memory.hpp"
 
 namespace hash {
-linear::linear() : ptr_(std::make_unique<table>()) {};
-linear::~linear() = default;
+namespace {
+uint64_t slot_hash(const uint8_t* slot) {
+  uint64_t h;
+  std::memcpy(&h, slot, sizeof(h));
+  return h;
+}
+
+uint64_t slot_offset(const uint8_t* slot) {
+  uint64_t offset;
+  std::memcpy(&offset, slot + sizeof(uint64_t), sizeof(offset));
+  return offset;
+}
+
+void write_slot(uint8_t* slot, uint64_t hash, uint64_t offset) {
+  std::memcpy(slot, &hash, sizeof(hash));
+  std::memcpy(slot + sizeof(uint64_t), &offset, sizeof(offset));
+}
+}
 
 uint64_t linear::operator()(std::string_view key) const {
   uint64_t h = XXH3_64bits(key.data(), key.size());
   if (!bloom_->contains(h)) {
     return 0;
   }
-  uint64_t pos = h % ptr_->capacity;
-  while (true) {
-    if (ptr_->table[pos].hash == 0) {
+  uint64_t pos = h % capacity_;
+  for (uint32_t probes = 0; probes < capacity_; probes++) {
+    const uint8_t* slot = slots_ + pos * SLOT_SIZE;
+    const uint64_t stored = slot_hash(slot);
+    if (stored == 0) {
       return 0;
     }
-    if (ptr_->table[pos].hash == h) {
-      return ptr_->table[pos].offset;
+    if (stored == h) {
+      return slot_offset(slot);
     }
-    pos = (pos + 1) % ptr_->capacity;
+    pos = (pos + 1) % capacity_;
   }
+  return 0;
 }
 
 void linear::build_to_file(const std::vector<std::pair<uint64_t, uint64_t>>& hash_entries,
                            const std::filesystem::path& path) {
-  ptr_->capacity = std::max<uint64_t>(hash_entries.size() * 10 / 7, 16);
-  size_t file_size = sizeof(uint32_t) + ptr_->capacity * sizeof(slot);
+  const uint32_t capacity = static_cast<uint32_t>(std::max<uint64_t>(hash_entries.size() * 10 / 7, 16));
+  const size_t file_size = sizeof(uint32_t) + static_cast<size_t>(capacity) * SLOT_SIZE;
 
   auto out = memory::map_rw(path, file_size);
   if (!out) {
     throw std::runtime_error("failed to create hash table");
   }
 
-  std::memcpy(out.data, &ptr_->capacity, sizeof(uint32_t));
-  ptr_->table = reinterpret_cast<slot*>(out.data + sizeof(uint32_t));
-  std::memset(ptr_->table, 0, ptr_->capacity * sizeof(slot));
-  for (const auto& he : hash_entries) {
-    uint64_t h = he.first;
-    uint64_t pos = h % ptr_->capacity;
-    while (true) {
-      if (ptr_->table[pos].hash == 0) {
-        ptr_->table[pos] = {.hash = h, .offset = he.second};
-        break;
-      }
-      pos = (pos + 1) % ptr_->capacity;
+  std::memcpy(out.data, &capacity, sizeof(capacity));
+  uint8_t* slots = out.data + sizeof(uint32_t);
+  std::memset(slots, 0, static_cast<size_t>(capacity) * SLOT_SIZE);
+  for (const auto& [h, offset] : hash_entries) {
+    uint64_t pos = h % capacity;
+    while (slot_hash(slots + pos * SLOT_SIZE) != 0) {
+      pos = (pos + 1) % capacity;
     }
+    write_slot(slots + pos * SLOT_SIZE, h, offset);
   }
   memory::unmap(out);
-  ptr_->table = nullptr;
-  ptr_->capacity = 0;
 }
 
-bool linear::load(uint8_t* ptr, size_t size) {
-  uint32_t capacity = *reinterpret_cast<uint32_t*>(ptr);
-  if (size != sizeof(uint32_t) + static_cast<size_t>(capacity) * sizeof(slot)) {
+bool linear::load(const uint8_t* ptr, size_t size) {
+  if (size < sizeof(uint32_t)) {
     return false;
   }
-  ptr_->capacity = capacity;
-  ptr_->table = reinterpret_cast<slot*>(ptr + sizeof(uint32_t));
+  uint32_t capacity;
+  std::memcpy(&capacity, ptr, sizeof(capacity));
+  if (capacity == 0) {
+    return false;
+  }
+  const size_t slots_bytes = size - sizeof(uint32_t);
+  if (slots_bytes / SLOT_SIZE != capacity || slots_bytes % SLOT_SIZE != 0) {
+    return false;
+  }
+  capacity_ = capacity;
+  slots_ = ptr + sizeof(uint32_t);
   return true;
 }
 }

--- a/src/hash/hash.hpp
+++ b/src/hash/hash.hpp
@@ -1,7 +1,8 @@
 #pragma once
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
-#include <memory>
+#include <string_view>
 #include <vector>
 
 #include "bloom.hpp"
@@ -9,25 +10,17 @@
 namespace hash {
 class linear {
  public:
-  linear();
-  ~linear();
   uint64_t operator()(std::string_view key) const;
 
   void build_to_file(const std::vector<std::pair<uint64_t, uint64_t>>& hash_entries, const std::filesystem::path& path);
-  bool load(uint8_t* ptr, size_t size);
+  bool load(const uint8_t* ptr, size_t size);
   void set_bloom(const bloom* b) { bloom_ = b; }
 
  private:
-  struct slot {
-    uint64_t hash;
-    uint64_t offset;
-  };
+  static constexpr size_t SLOT_SIZE = 2 * sizeof(uint64_t);
 
-  struct table {
-    uint32_t capacity = 0;
-    slot* table;
-  };
-  std::unique_ptr<table> ptr_;
+  const uint8_t* slots_ = nullptr;
+  uint32_t capacity_ = 0;
   const bloom* bloom_ = nullptr;
 };
 }

--- a/src/hoshidicts_c.cpp
+++ b/src/hoshidicts_c.cpp
@@ -1,11 +1,14 @@
 #include "hoshidicts_c.h"
 
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 
+#include "hoshidicts/container.hpp"
 #include "hoshidicts/deinflector.hpp"
 #include "hoshidicts/importer.hpp"
 #include "hoshidicts/lookup.hpp"
@@ -54,6 +57,77 @@ uint64_t hd_import_result_kanji_count(const hd_import_result* r) { return r->res
 uint64_t hd_import_result_media_count(const hd_import_result* r) { return r->result.summary.counts.media.total; }
 
 const char* hd_import_result_error(const hd_import_result* r) { return r->result.error.c_str(); }
+
+static char* duplicate(const std::string& value) {
+  auto* copy = new char[value.size() + 1];
+  std::memcpy(copy, value.c_str(), value.size() + 1);
+  return copy;
+}
+
+static void store_error(char** error, const std::string& message) {
+  if (error != nullptr) {
+    *error = duplicate(message);
+  }
+}
+
+int hd_container_pack(const char* dictionary_dir, const char* output_path, char** error) {
+  try {
+    const auto result = dictionary_container::pack(dictionary_dir, output_path);
+    if (!result.ok) {
+      store_error(error, result.error);
+      return 1;
+    }
+    return 0;
+  } catch (const std::exception& e) {
+    store_error(error, e.what());
+    return 1;
+  } catch (...) {
+    store_error(error, "could not pack the dictionary");
+    return 1;
+  }
+}
+
+int hd_container_verify(const char* container_path, uint32_t* payload_version, char** error) {
+  try {
+    const auto result = dictionary_container::verify(container_path);
+    if (!result.ok) {
+      store_error(error, result.error);
+      return 1;
+    }
+    if (payload_version != nullptr) {
+      *payload_version = result.container.payload_version;
+    }
+    return 0;
+  } catch (const std::exception& e) {
+    store_error(error, e.what());
+    return 1;
+  } catch (...) {
+    store_error(error, "could not verify the container");
+    return 1;
+  }
+}
+
+int hd_container_index(const char* container_path, char** index_json, char** error) {
+  try {
+    const auto result = dictionary_container::read_index(container_path);
+    if (!result.ok) {
+      store_error(error, result.error);
+      return 1;
+    }
+    if (index_json != nullptr) {
+      *index_json = duplicate(result.json);
+    }
+    return 0;
+  } catch (const std::exception& e) {
+    store_error(error, e.what());
+    return 1;
+  } catch (...) {
+    store_error(error, "could not read the container index");
+    return 1;
+  }
+}
+
+void hd_container_string_free(char* value) { delete[] value; }
 
 // deinflector
 struct hd_deinflector {

--- a/src/zip/zip.cpp
+++ b/src/zip/zip.cpp
@@ -130,9 +130,17 @@ bool Zip::parse_central_directory() {
     auto lfh_offset = read_at<uint32_t>(base, pos + 42);
     e.name.assign(reinterpret_cast<const char*>(base + pos + 46), name_len);
 
+    if (lfh_offset > file.size || file.size - lfh_offset < 30) {
+      return false;
+    }
     auto lfh_name_len = read_at<uint16_t>(base, lfh_offset + 26);
     auto lfh_extra_len = read_at<uint16_t>(base, lfh_offset + 28);
     e.data_offset = lfh_offset + 30 + lfh_name_len + lfh_extra_len;
+
+    const uint32_t data_size = e.compression_method == 0 ? e.uncompressed_size : e.compressed_size;
+    if (e.data_offset > file.size || file.size - e.data_offset < data_size) {
+      return false;
+    }
 
     entries.push_back(std::move(e));
     pos += 46 + name_len + extra_len + comment_len;


### PR DESCRIPTION
Adds a single-file `.hoshi` container that wraps the directory an import already produces, so a dictionary can be shipped and mapped as one file. This PR is the format, the packer and the CLI; loading a container in `DictionaryQuery` is a follow-up so this one stays reviewable.

Every offset in the payload is already relative to the start of its own file, so the container concatenates the files byte for byte behind a 64-byte header and a section table. No payload bytes change, no index layout changes, and nothing in the lookup path is touched.

- The `Container format` section of the README has the byte tables.
- `open()` validates the header and the table only — magic, versions, alignment, bounds, overflow, duplicates, overlaps, required sections. It never hashes payloads, which is the point.
- `verify()` adds an XXH3-64 check of every section, for a build pipeline and for a one-time check after a download.
- `read_index()` returns the `INDEX` section verbatim: the summary the import wrote, carrying `title`, `revision` and the entry `counts`. Enough to identify a container and tell a term dictionary from a kanji or IPA one without mapping it.
- `pack()` streams each file through a 1 MiB buffer while folding its checksum, so its memory use does not scale with the dictionary. It writes `<output>.tmp`, backpatches, reopens, runs the full `verify()`, and only then renames into place.
- `hoshidicts-cli pack <dir> <out.hoshi>`, `verify <file.hoshi>` and `index <file.hoshi>`, non-zero on failure. `verify` prints `payload_version:` and per-section lengths so a build script can assert on them.
- `hd_container_pack` / `hd_container_verify` / `hd_container_index` / `hd_container_string_free`, additive, no ABI break.

Sections are 64-byte aligned because the mapped hash and bloom sections are read at section offset 0 and +8. Both loaders now read every mapped field through `memcpy` rather than a `reinterpret_cast`, so a section that is mapped at any alignment can no longer produce misaligned-access undefined behaviour on the valid-container query path. Lengths are exact — both loaders reject a size that is not exactly the size derived from the bytes, so padding is never inside a view — and the loaders also reject a zero or non-power-of-two bloom bit count and a zero hash capacity, which previously divided by zero or walked a zero-length map on a malformed payload.

Payload v1 and v2 are out of scope: they may carry a separate `styles.css`, which has no section, and neither is redistributed.

Two things worth knowing. `pack` is deterministic for a given directory, but the importer is not — `index.json` carries `importDate` — so importing the same zip twice and packing both gives two different containers; the README says so rather than promising reproducibility. And a container that passes `open()` but has corrupt payload bytes still yields zero results rather than an error, because `add_dict` returns bare on failure and `hd_query_add_term_dict` always returns 0. That is pre-existing behaviour for directories, and `verify` covers the path where bytes are produced and published; making that path return a truthful error is deferred to the query-integration follow-up so this PR stays scoped to the format.

The ZIP reader used by import validates each central-directory entry's local-header offset and data offset against the file size before dereferencing them, so a crafted archive cannot read past the mapping.

There are no tests in this PR, to keep it to the feature and avoid introducing a test target and a fixture to a repo that has neither. I did exercise it out of tree while developing: pack round-trip and byte-identical repacking, and rejection of bad magic, wrong container version, unsupported payload version, a clear endian flag, truncated header, truncated section table, wrong declared size, missing required section, duplicate type, overlapping ranges, misaligned offset, offset inside the header, empty section, out-of-bounds length, `offset + length` overflow, payload v4 without a zstd dictionary, media without a media index, and unknown section types with and without `REQUIRED`. The loader-hardening and ZIP-bounds fixes above were exercised under AddressSanitizer and UndefinedBehaviorSanitizer on a real import→pack fixture: a clean directory query no longer trips the alignment check, a zero-capacity hash table and a zero-bit bloom filter are rejected instead of crashing, and pack stays byte-identical across two runs of the same directory. Happy to bring any of that in as a committed test target if you want it.

---

*AI-assistance disclosure: this contribution was prepared with the help of an AI coding assistant. All code was reviewed, built, and exercised under sanitizers before submission; the author takes responsibility for it.*
